### PR TITLE
Fixed a error during launching channel with deep-linking parameter

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "roku-test-automation",
-    "version": "1.0.0",
+    "version": "1.0.32",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -608,6 +608,11 @@
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "deep-eql": {
             "version": "3.0.1",
@@ -1678,6 +1683,16 @@
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
             "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         },
+        "query-string": {
+            "version": "6.12.1",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.12.1.tgz",
+            "integrity": "sha512-OHj+zzfRMyj3rmo/6G8a5Ifvw3AleL/EbcHMD27YA31Q+cO5lfmQxECkImuNVjcskLcvBRVHNAB3w6udMs1eAA==",
+            "requires": {
+                "decode-uri-component": "^0.2.0",
+                "split-on-first": "^1.0.0",
+                "strict-uri-encode": "^2.0.0"
+            }
+        },
         "range-parser": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1953,6 +1968,11 @@
             "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
             "dev": true
         },
+        "split-on-first": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+            "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1963,6 +1983,11 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        },
+        "strict-uri-encode": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+            "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         },
         "string-width": {
             "version": "3.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roku-test-automation",
-    "version": "1.0.30",
+    "version": "1.0.33",
     "description": "Helps with automating functional tests",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
@@ -26,10 +26,11 @@
     "dependencies": {
         "express": "^4.17.1",
         "fs-extra": "^7.0.1",
+        "http-proxy-middleware": "^1.0.3",
         "needle": "^2.3.2",
         "path": "^0.12.7",
-        "ts-interface-checker": "^0.1.10",
-        "http-proxy-middleware": "^1.0.3"
+        "query-string": "^6.12.1",
+        "ts-interface-checker": "^0.1.10"
     },
     "devDependencies": {
         "@types/chai": "^4.1.2",

--- a/server/src/RokuDevice.ts
+++ b/server/src/RokuDevice.ts
@@ -1,7 +1,7 @@
 import * as needle from 'needle';
-import querystring from 'needle/lib/querystring';
 import { ScreenshotFormat } from './types/ConfigOptions';
 import * as utils from './utils';
+import { stringify } from 'query-string';
 
 export class RokuDevice {
 	public ip: string;
@@ -23,7 +23,7 @@ export class RokuDevice {
 		let url = `http://${this.ip}:8060/${path}`;
 
 		if (params && Object.keys(params).length) {
-			url = url.replace(/\?.*|$/, '?' + querystring.build(params));
+			url = url.replace(/\?.*|$/, '?' + stringify(params));
 		}
 
 		if (body !== undefined) {


### PR DESCRIPTION
when trying to execute with deep-linking it was throwing below error since the query string build method was not exported through the @types/needle

 TypeError: Cannot read property 'build' of undefined
      at RokuDevice.<anonymous> (node_modules/roku-test-automation/dist/RokuDevice.js:61:85)
      at step (node_modules/roku-test-automation/dist/RokuDevice.js:33:23)
      at Object.next (node_modules/roku-test-automation/dist/RokuDevice.js:14:53)
      at /Users/prajwalshetty/Documents/www/Roku-MK-LiteBright-Component-Library/node_modules/roku-test-automation/dist/RokuDevice.js:8:71
      at new Promise (<anonymous>)
      at __awaiter (node_modules/roku-test-automation/dist/RokuDevice.js:4:12)
      at RokuDevice.sendECP (node_modules/roku-test-automation/dist/RokuDevice.js:54:16)
      at ECP.<anonymous> (node_modules/roku-test-automation/dist/ECP.js:148:58)
      at step (node_modules/roku-test-automation/dist/ECP.js:44:23)
      at Object.next (node_modules/roku-test-automation/dist/ECP.js:25:53)
      at /Users/prajwalshetty/Documents/www/Roku-MK-LiteBright-Component-Library/node_modules/roku-test-automation/dist/ECP.js:19:71
      at new Promise (<anonymous>)
      at __awaiter (node_modules/roku-test-automation/dist/ECP.js:15:12)
      at ECP.sendLaunchChannel (node_modules/roku-test-automation/dist/ECP.js:136:16)
      at Object.<anonymous> (UITests/test/common.js:50:46)
      at step (UITests/test/common.js:33:23)
      at Object.next (UITests/test/common.js:14:53)
      at fulfilled (UITests/test/common.js:5:58)

