### PR TITLE
Switch timeouts to be based on individual devices

### DIFF
--- a/server/rta-config.schema.json
+++ b/server/rta-config.schema.json
@@ -53,6 +53,10 @@
                     "items": {
                         "additionalProperties": false,
                         "properties": {
+                            "defaultTimeout": {
+                                "description": "If not overridden at the call site how long to wait before assuming a request failed",
+                                "type": "number"
+                            },
                             "host": {
                                 "description": "The IP address or hostname of the target Roku device.",
                                 "type": "string"
@@ -74,6 +78,10 @@
                                     "png"
                                 ],
                                 "type": "string"
+                            },
+                            "timeoutMultiplier": {
+                                "description": "Multiplier applied to request timeouts for all requests including those with an explicit value. Can be used in combination with defaultTimeout",
+                                "type": "number"
                             }
                         },
                         "type": "object"

--- a/server/src/types/ConfigOptions.ts
+++ b/server/src/types/ConfigOptions.ts
@@ -27,6 +27,12 @@ export interface DeviceConfigOptions {
 	/** The password for logging in to the developer portal on the target Roku device */
 	password: string;
 
+	/** If not overridden at the call site how long to wait before assuming a request failed */
+	defaultTimeout?: number;
+
+	/** Multiplier applied to request timeouts for all requests including those with an explicit value. Can be used in combination with defaultTimeout */
+	timeoutMultiplier?: number;
+
 	/** User defined list of properties for this device (name, isLowEnd, etc) */
 	properties: {};
 


### PR DESCRIPTION
Switch timeouts to be based on individual devices to allow for quicker timeouts on high end devices. Allow multiplier and default time out override.