### PR TITLE
feature: enable getting media player

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,11 @@ If you did all the steps above correct you should be ready to start making use o
 
 RTA contains most of the standard ECP commands including:
 
--   Launching/deeplinking into a channel
--   Sending keypress and keypress sequences to the device
--   Sending text to the device
--   Getting the current active app
+- Launching/deeplinking into a channel
+- Sending keypress and keypress sequences to the device
+- Sending text to the device
+- Getting the current active app
+- Getting the media player
 
 ---
 

--- a/server/src/ECP.spec.ts
+++ b/server/src/ECP.spec.ts
@@ -233,4 +233,126 @@ describe('ECP', function () {
 			});
 		});
 	});
+
+	describe('getMediaPlayer', function () {
+		it('app_closed', async () => {
+			ecpResponse = await utils.getNeedleMockResponse(this);
+			const result = await ecp.getMediaPlayer();
+			expect(result.state).to.equal('close');
+			expect(result.error).to.equal(false);
+			expect(result.plugin).to.not.be.ok;
+		});
+
+		it('player_closed', async () => {
+			ecpResponse = await utils.getNeedleMockResponse(this);
+			const result = await ecp.getMediaPlayer();
+
+			expect(result.state).to.equal('close');
+			expect(result.error).to.equal(false);
+
+			expect(result.plugin?.bandwidth).to.equal('19111730 bps');
+			expect(result.plugin?.id).to.equal('dev');
+			expect(result.plugin?.name).to.equal('App name');
+		});
+
+		it('player_startup', async () => {
+			ecpResponse = await utils.getNeedleMockResponse(this);
+			const result = await ecp.getMediaPlayer();
+
+			expect(result.state).to.equal('startup');
+			expect(result.error).to.equal(false);
+
+			expect(result.plugin?.bandwidth).to.equal('19111730 bps');
+			expect(result.plugin?.id).to.equal('dev');
+			expect(result.plugin?.name).to.equal('App name');
+
+			expect(result.buffering?.current).to.equal('0');
+			expect(result.buffering?.max).to.equal('1000');
+			expect(result.buffering?.target).to.equal('1000');
+
+			expect(result.new_stream?.speed).to.equal('128000 bps');
+
+			expect(result.duration?.value).to.equal('8551626 ms');
+
+			expect(result.is_live?.value).to.equal('false');
+		});
+
+		it('player_buffering', async () => {
+			ecpResponse = await utils.getNeedleMockResponse(this);
+			const result = await ecp.getMediaPlayer();
+
+			expect(result.state).to.equal('buffer');
+			expect(result.error).to.equal(false);
+
+			expect(result.plugin?.bandwidth).to.equal('19111730 bps');
+			expect(result.plugin?.id).to.equal('dev');
+			expect(result.plugin?.name).to.equal('App name');
+
+			expect(result.buffering?.current).to.equal('0');
+			expect(result.buffering?.max).to.equal('1000');
+			expect(result.buffering?.target).to.equal('1000');
+
+			expect(result.new_stream?.speed).to.equal('128000 bps');
+
+			expect(result.duration?.value).to.equal('8551626 ms');
+
+			expect(result.is_live?.value).to.equal('false');
+		});
+
+		it('player_playing', async () => {
+			ecpResponse = await utils.getNeedleMockResponse(this);
+			const result = await ecp.getMediaPlayer();
+
+			expect(result.state).to.equal('play');
+			expect(result.error).to.equal(false);
+
+			expect(result.plugin?.bandwidth).to.equal('19111730 bps');
+			expect(result.plugin?.id).to.equal('dev');
+			expect(result.plugin?.name).to.equal('App name');
+
+			expect(result.format?.audio).to.equal('aac_adts');
+			expect(result.format?.captions).to.equal('webvtt');
+			expect(result.format?.container).to.equal('hls');
+			expect(result.format?.drm).to.equal('none');
+			expect(result.format?.video).to.equal('mpeg4_10b');
+
+			expect(result.buffering?.current).to.equal('1000');
+			expect(result.buffering?.max).to.equal('1000');
+			expect(result.buffering?.target).to.equal('0');
+
+			expect(result.new_stream?.speed).to.equal('128000 bps');
+
+			expect(result.duration?.value).to.equal('8551626 ms');
+
+			expect(result.is_live?.value).to.equal('false');
+		});
+
+		it('player_paused', async () => {
+			ecpResponse = await utils.getNeedleMockResponse(this);
+			const result = await ecp.getMediaPlayer();
+
+			expect(result.state).to.equal('pause');
+			expect(result.error).to.equal(false);
+
+			expect(result.plugin?.bandwidth).to.equal('19111730 bps');
+			expect(result.plugin?.id).to.equal('dev');
+			expect(result.plugin?.name).to.equal('App name');
+
+			expect(result.format?.audio).to.equal('aac_adts');
+			expect(result.format?.captions).to.equal('webvtt');
+			expect(result.format?.container).to.equal('hls');
+			expect(result.format?.drm).to.equal('none');
+			expect(result.format?.video).to.equal('mpeg4_10b');
+
+			expect(result.buffering?.current).to.equal('1000');
+			expect(result.buffering?.max).to.equal('1000');
+			expect(result.buffering?.target).to.equal('0');
+
+			expect(result.new_stream?.speed).to.equal('128000 bps');
+
+			expect(result.duration?.value).to.equal('8551626 ms');
+
+			expect(result.is_live?.value).to.equal('false');
+		});
+	});
 });

--- a/server/src/ECP.ts
+++ b/server/src/ECP.ts
@@ -3,6 +3,7 @@ import { ActiveAppResponse } from './types/ActiveAppResponse';
 import { ConfigOptions } from './types/ConfigOptions';
 import { ECPKeys } from './types/ECPKeys';
 import { utils } from './utils';
+import { MediaPlayerResponse } from './types/MediaPlayerResponse';
 
 export class ECP {
 	//store the import on the class to make testing easier
@@ -101,6 +102,26 @@ export class ECP {
 				title: child.value
 			};
 		}
+		return response;
+	}
+
+	public async getMediaPlayer() {
+		const result = await this.device.sendECP(`query/media-player`);
+		const player = result.body;
+		if (!player) throw utils.makeError('getMediaPlayerInvalidResponse', 'Received invalid media-player response from device');
+
+		const response: MediaPlayerResponse = {
+			state: player.attributes.state,
+			error: player.attributes.error === 'true',
+		};
+
+		for (let child of player.children) {
+			response[child.name] = {
+				...child.attributes,
+				value: child.value
+			};
+		}
+
 		return response;
 	}
 }

--- a/server/src/test/mocks/ECP/getMediaPlayer/app_closed.json
+++ b/server/src/test/mocks/ECP/getMediaPlayer/app_closed.json
@@ -1,0 +1,9 @@
+{
+  "name": "player",
+  "value": "",
+  "attributes": {
+    "error": "false",
+    "state": "close"
+  },
+  "children": []
+}

--- a/server/src/test/mocks/ECP/getMediaPlayer/player_buffering.json
+++ b/server/src/test/mocks/ECP/getMediaPlayer/player_buffering.json
@@ -1,0 +1,50 @@
+{
+  "name": "player",
+  "value": "",
+  "attributes": {
+    "error": "false",
+    "state": "buffer"
+  },
+  "children": [
+    {
+      "name": "plugin",
+      "value": "",
+      "attributes": {
+        "bandwidth": "19111730 bps",
+        "id": "dev",
+        "name": "App name"
+      },
+      "children": []
+    },
+    {
+      "name": "buffering",
+      "value": "",
+      "attributes": {
+        "current": "0",
+        "max": "1000",
+        "target": "1000"
+      },
+      "children": []
+    },
+    {
+      "name": "new_stream",
+      "value": "",
+      "attributes": {
+        "speed": "128000 bps"
+      },
+      "children": []
+    },
+    {
+      "name": "duration",
+      "value": "8551626 ms",
+      "attributes": {},
+      "children": []
+    },
+    {
+      "name": "is_live",
+      "value": "false",
+      "attributes": {},
+      "children": []
+    }
+  ]
+}

--- a/server/src/test/mocks/ECP/getMediaPlayer/player_closed.json
+++ b/server/src/test/mocks/ECP/getMediaPlayer/player_closed.json
@@ -1,0 +1,17 @@
+{
+  "name": "player",
+  "value": "",
+  "attributes": {
+    "error": "false",
+    "state": "close"
+  },
+  "children": [{
+    "name": "plugin",
+    "value": "",
+    "attributes": {
+      "bandwidth": "19111730 bps",
+      "id": "dev",
+      "name": "App name"
+    }
+  }]
+}

--- a/server/src/test/mocks/ECP/getMediaPlayer/player_paused.json
+++ b/server/src/test/mocks/ECP/getMediaPlayer/player_paused.json
@@ -1,0 +1,62 @@
+{
+  "name": "player",
+  "value": "",
+  "attributes": {
+    "error": "false",
+    "state": "pause"
+  },
+  "children": [
+    {
+      "name": "plugin",
+      "value": "",
+      "attributes": {
+        "bandwidth": "19111730 bps",
+        "id": "dev",
+        "name": "App name"
+      },
+      "children": []
+    },
+    {
+      "name": "format",
+      "value": "",
+      "attributes": {
+        "audio": "aac_adts",
+        "captions": "webvtt",
+        "container": "hls",
+        "drm": "none",
+        "video": "mpeg4_10b"
+      },
+      "children": []
+    },
+    {
+      "name": "buffering",
+      "value": "",
+      "attributes": {
+        "current": "1000",
+        "max": "1000",
+        "target": "0"
+      },
+      "children": []
+    },
+    {
+      "name": "new_stream",
+      "value": "",
+      "attributes": {
+        "speed": "128000 bps"
+      },
+      "children": []
+    },
+    {
+      "name": "duration",
+      "value": "8551626 ms",
+      "attributes": {},
+      "children": []
+    },
+    {
+      "name": "is_live",
+      "value": "false",
+      "attributes": {},
+      "children": []
+    }
+  ]
+}

--- a/server/src/test/mocks/ECP/getMediaPlayer/player_playing.json
+++ b/server/src/test/mocks/ECP/getMediaPlayer/player_playing.json
@@ -1,0 +1,62 @@
+{
+  "name": "player",
+  "value": "",
+  "attributes": {
+    "error": "false",
+    "state": "play"
+  },
+  "children": [
+    {
+      "name": "plugin",
+      "value": "",
+      "attributes": {
+        "bandwidth": "19111730 bps",
+        "id": "dev",
+        "name": "App name"
+      },
+      "children": []
+    },
+    {
+      "name": "format",
+      "value": "",
+      "attributes": {
+        "audio": "aac_adts",
+        "captions": "webvtt",
+        "container": "hls",
+        "drm": "none",
+        "video": "mpeg4_10b"
+      },
+      "children": []
+    },
+    {
+      "name": "buffering",
+      "value": "",
+      "attributes": {
+        "current": "1000",
+        "max": "1000",
+        "target": "0"
+      },
+      "children": []
+    },
+    {
+      "name": "new_stream",
+      "value": "",
+      "attributes": {
+        "speed": "128000 bps"
+      },
+      "children": []
+    },
+    {
+      "name": "duration",
+      "value": "8551626 ms",
+      "attributes": {},
+      "children": []
+    },
+    {
+      "name": "is_live",
+      "value": "false",
+      "attributes": {},
+      "children": []
+    }
+  ]
+}

--- a/server/src/test/mocks/ECP/getMediaPlayer/player_startup.json
+++ b/server/src/test/mocks/ECP/getMediaPlayer/player_startup.json
@@ -1,0 +1,50 @@
+{
+  "name": "player",
+  "value": "",
+  "attributes": {
+    "error": "false",
+    "state": "startup"
+  },
+  "children": [
+    {
+      "name": "plugin",
+      "value": "",
+      "attributes": {
+        "bandwidth": "19111730 bps",
+        "id": "dev",
+        "name": "App name"
+      },
+      "children": []
+    },
+    {
+      "name": "buffering",
+      "value": "",
+      "attributes": {
+        "current": "0",
+        "max": "1000",
+        "target": "1000"
+      },
+      "children": []
+    },
+    {
+      "name": "new_stream",
+      "value": "",
+      "attributes": {
+        "speed": "128000 bps"
+      },
+      "children": []
+    },
+    {
+      "name": "duration",
+      "value": "8551626 ms",
+      "attributes": {},
+      "children": []
+    },
+    {
+      "name": "is_live",
+      "value": "false",
+      "attributes": {},
+      "children": []
+    }
+  ]
+}

--- a/server/src/types/MediaPlayerResponse.ts
+++ b/server/src/types/MediaPlayerResponse.ts
@@ -1,5 +1,5 @@
 export interface MediaPlayerResponse {
-	state: string;
+	state: 'close' | 'startup' | 'buffer' | 'play' | 'pause';
 	error: boolean;
 	plugin?: MediaPlayerPlugin;
 	format?: MediaPlayerFormat;

--- a/server/src/types/MediaPlayerResponse.ts
+++ b/server/src/types/MediaPlayerResponse.ts
@@ -1,0 +1,62 @@
+export interface MediaPlayerResponse {
+	state: string;
+	error: boolean;
+	plugin?: MediaPlayerPlugin;
+	format?: MediaPlayerFormat;
+	buffering?: MediaPlayerBuffering;
+	new_stream?: MediaPlayerNewStream;
+	position?: MediaPlayerPosition;
+	duration?: MediaPlayerDuration;
+	is_live?: MediaPlayerIsLive;
+	runtime?: MediaPlayerRuntime;
+	stream_segment?: MediaPlayerStreamSegment;
+}
+
+export interface MediaPlayerPlugin {
+	bandwidth: string;
+	id: string;
+	name: string;
+}
+
+export interface MediaPlayerFormat {
+	audio: string;
+	captions: string;
+	container: string;
+	drm: string;
+	video: string;
+}
+
+export interface MediaPlayerBuffering {
+	current: string;
+	max: string;
+	target: string;
+}
+
+export interface MediaPlayerNewStream {
+	speed: string;
+}
+
+export interface MediaPlayerPosition {
+	value: string;
+}
+
+export interface MediaPlayerDuration {
+	value: string;
+}
+
+export interface MediaPlayerIsLive {
+	value: string;
+}
+
+export interface MediaPlayerRuntime {
+	value: string;
+}
+
+export interface MediaPlayerStreamSegment {
+	bitrate: string;
+	height: string;
+	media_sequence: string;
+	segment_type: string;
+	time: string;
+	width: string;
+}


### PR DESCRIPTION
This MR adds support for the native ECP api `query/media-player` for getting the media player along with the relevant information about it.

We needed a way to easily get the player state, and with these changes, users can now get media player by calling `getMediaPlayer()` directly on ECP. 

I have intentionally left the player properties to be snake case, for consistency with the native API. Another thing to note is that attribute values are not converted to the correct type, everything is left as is (ie `attribute="false"` will have string value of `"false"`, rather than boolean). This could be changed, but I wasn't sure it was worth it for now.