### PR TITLE
Add retry logic for ECP requests, on failure return our own error to make it more clear what failed

### DIFF
--- a/client/base-rta-config.json
+++ b/client/base-rta-config.json
@@ -1,6 +1,7 @@
 {
     "$schema": "./rta-config.schema.json",
     "RokuDevice": {
+        "clientDebugLogging": false,
         "devices": []
     },
     "OnDeviceComponent": {

--- a/client/rta-config.schema.json
+++ b/client/rta-config.schema.json
@@ -120,6 +120,10 @@
         "RokuDevice": {
             "additionalProperties": false,
             "properties": {
+                "clientDebugLogging": {
+                    "description": "Enable debug logging on the client side",
+                    "type": "boolean"
+                },
                 "deviceIndex": {
                     "description": "zero based index of which `devices` index to use. If not provided defaults to 0",
                     "type": "number"

--- a/client/src/ECP.ts
+++ b/client/src/ECP.ts
@@ -1,3 +1,4 @@
+import type { HttpRequestOptions} from './RokuDevice';
 import { RokuDevice } from './RokuDevice';
 import type { ActiveAppResponse } from './types/ActiveAppResponse';
 import type { ConfigOptions } from './types/ConfigOptions';
@@ -157,14 +158,15 @@ export class ECP {
 		channelId = '',
 		params = {},
 		verifyLaunch = true,
-		verifyLaunchTimeOut = 3000
+		verifyLaunchTimeOut = 3000,
+		options = {} as HttpRequestOptions
 	} = {}) {
 		channelId = this.getChannelId(channelId);
 
 		// We always append a param as if none is passed and the application is already running it will not restart the application
 		params['RTA_LAUNCH'] = 1;
 
-		await this.device.sendEcpPost(`launch/${channelId}`, params);
+		await this.device.sendEcpPost(`launch/${channelId}`, params, undefined, options);
 		if (verifyLaunch) {
 			const startTime = new Date();
 			while (new Date().valueOf() - startTime.valueOf() < verifyLaunchTimeOut) {
@@ -181,13 +183,14 @@ export class ECP {
 
 	// Helper for sending a /input request to the device that can be handled via roInput
 	public async sendInput({
-		params = {}
+		params = {},
+		options = {} as HttpRequestOptions
 	} = {}) {
-		await this.device.sendEcpPost(`input`, params);
+		await this.device.sendEcpPost(`input`, params, undefined, options);
 	}
 
-	public async getActiveApp() {
-		const result = await this.device.sendEcpGet(`query/active-app`);
+	public async getActiveApp(options: HttpRequestOptions = {}) {
+		const result = await this.device.sendEcpGet(`query/active-app`, undefined, options);
 		const children = result.body?.children;
 		if (!children) throw this.utils.makeError('getActiveAppInvalidResponse', 'Received invalid active-app response from device');
 
@@ -212,13 +215,13 @@ export class ECP {
 		return channelId;
 	}
 
-	public async isActiveApp(channelId?: string) {
-		const result = await this.getActiveApp();
+	public async isActiveApp(channelId?: string, options: HttpRequestOptions = {}) {
+		const result = await this.getActiveApp(options);
 		return result.app?.id === this.getChannelId(channelId);
 	}
 
-	public async getMediaPlayer() {
-		const result = await this.device.sendEcpGet(`query/media-player`);
+	public async getMediaPlayer(options: HttpRequestOptions = {}) {
+		const result = await this.device.sendEcpGet(`query/media-player`, undefined, options);
 		const player = result.body;
 		if (!player) throw this.utils.makeError('getMediaPlayerInvalidResponse', 'Received invalid media-player response from device');
 
@@ -244,8 +247,8 @@ export class ECP {
 		return response;
 	}
 
-	public async getChanperf() {
-		const {body} = await this.device.sendEcpGet(`query/chanperf`);
+	public async getChanperf(options: HttpRequestOptions = {}) {
+		const {body} = await this.device.sendEcpGet(`query/chanperf`, undefined, options);
 
 		const response = this.simplifyEcpResponse(body);
 		const plugin = response.plugin;

--- a/client/src/types/ConfigOptions.ts
+++ b/client/src/types/ConfigOptions.ts
@@ -19,6 +19,9 @@ export interface ConfigOptions {
 }
 
 export interface RokuDeviceConfigOptions {
+	/** Enable debug logging on the client side */
+	clientDebugLogging?: boolean;
+
 	devices: DeviceConfigOptions[];
 
 	/** zero based index of which `devices` index to use. If not provided defaults to 0 */

--- a/client/src/types/OnDeviceComponent.ts
+++ b/client/src/types/OnDeviceComponent.ts
@@ -1,5 +1,4 @@
 import type { Socket } from 'net';
-import type * as ODC from './OnDeviceComponent';
 
 export enum RequestType {
 	callFunc = 'callFunc',
@@ -398,5 +397,5 @@ export interface GetApplicationStartTimeArgs {}
 export interface GetServerHostArgs {}
 
 export interface SetSettingsArgs {
-	logLevel: ODC.LogLevels;
+	logLevel: LogLevels;
 }


### PR DESCRIPTION
This is been one of the issues I've struggled to track down for a while as it doesn't happen often and when it does the only message was `socket hang up`. I thought this was due to our socket logic between our code on the client and the component running on the device but this proved not to be true. We were not handling any errors when an ECP request fails and this was causing it ultimately bubble up the `socket hang up` error inside of Node. Now we will attempt to retry the request if retryCount is more than 0 and will throw a more useful error for the person running into the issue.