### PR TITLE
Rename unused args

### DIFF
--- a/device/components/RTA_OnDeviceComponent.brs
+++ b/device/components/RTA_OnDeviceComponent.brs
@@ -549,7 +549,7 @@ function processSetValueRequest(request as Object) as Object
 	return {}
 end function
 
-function processGetAllCountRequest(_args as Object) as Object
+function processGetAllCountRequest(_request as Object) as Object
 	return calculateNodeCount(m.top.getAll())
 end function
 

--- a/device/components/RTA_OnDeviceComponent.brs
+++ b/device/components/RTA_OnDeviceComponent.brs
@@ -553,7 +553,7 @@ function processGetAllCountRequest(_args as Object) as Object
 	return calculateNodeCount(m.top.getAll())
 end function
 
-function processGetRootsCountRequest(_args as Object) as Object
+function processGetRootsCountRequest(_request as Object) as Object
 	return calculateNodeCount(m.top.getRoots())
 end function
 

--- a/device/components/RTA_OnDeviceComponent.brs
+++ b/device/components/RTA_OnDeviceComponent.brs
@@ -549,11 +549,11 @@ function processSetValueRequest(request as Object) as Object
 	return {}
 end function
 
-function processGetAllCountRequest(args as Object) as Object
+function processGetAllCountRequest(_args as Object) as Object
 	return calculateNodeCount(m.top.getAll())
 end function
 
-function processGetRootsCountRequest(args as Object) as Object
+function processGetRootsCountRequest(_args as Object) as Object
 	return calculateNodeCount(m.top.getRoots())
 end function
 
@@ -1135,7 +1135,7 @@ function processStartResponsivenessTestingRequest(request as Object) as Object
 	return {}
 end function
 
-function processStopResponsivenessTestingRequest(request as Object) as Object
+function processStopResponsivenessTestingRequest(_request as Object) as Object
 	if m.responsivenessTestingTickTimer <> invalid then
 		m.responsivenessTestingTickTimer.control = "stop"
 		m.responsivenessTestingCurrentPeriodTimer.control = "stop"
@@ -1177,7 +1177,7 @@ sub onResponsivenessTestingCurrentPeriodTimerFire()
 	end while
 end sub
 
-function processGetResponsivenessTestingDataRequest(request as Object) as Object
+function processGetResponsivenessTestingDataRequest(_request as Object) as Object
 	if m.responsivenessTestingData = invalid then
 		return RTA_buildErrorResponseObject("Responsiveness testing is not started. Be sure to call 'startResponsivenessTesting()' first")
 	end if


### PR DESCRIPTION
Rename unused args to silence warnings
```
BRIGHTSCRIPT: WARNING: unused variable 'args' in function 'processgetallcountrequest' in pkg:/components/RTA_OnDeviceComponent.brs(552)
BRIGHTSCRIPT: WARNING: unused variable 'args' in function 'processgetrootscountrequest' in pkg:/components/RTA_OnDeviceComponent.brs(556)
BRIGHTSCRIPT: WARNING: unused variable 'request' in function 'processstopresponsivenesstestingrequest' in pkg:/components/RTA_OnDeviceComponent.brs(1138)
BRIGHTSCRIPT: WARNING: unused variable 'request' in function 'processgetresponsivenesstestingdatarequest' in pkg:/components/RTA_OnDeviceComponent.brs(1180)
```

> Tagging unused variables (Available since Roku OS 11.0) – Variables can explicitly be marked as unused by prepending an underscore to the value (for example, sub myTask(_x)). This enables avoid compilation errors to occur when an unused variable, for example, has a special behavior or another valid purpose. Unused variables generate warnings that are output to the SceneGraph debug port (8085). The maximum number of warnings that may be generated is 100.
