### PR TITLE
Debug logging displays the wrong month.

### DIFF
--- a/client/src/OnDeviceComponent.ts
+++ b/client/src/OnDeviceComponent.ts
@@ -1019,7 +1019,7 @@ export class OnDeviceComponent {
 	private debugLog(message: string, ...args) {
 		if (this.getConfig()?.clientDebugLogging) {
 			const date = new Date;
-			const formattedDate = `${utils.lpad(date.getMonth())}-${utils.lpad(date.getDate())} ${utils.lpad(date.getHours())}:${utils.lpad(date.getMinutes())}:${utils.lpad(date.getSeconds())}:${utils.lpad(date.getMilliseconds(), 3)}`;
+			const formattedDate = `${utils.lpad(date.getMonth() + 1)}-${utils.lpad(date.getDate())} ${utils.lpad(date.getHours())}:${utils.lpad(date.getMinutes())}:${utils.lpad(date.getSeconds())}:${utils.lpad(date.getMilliseconds(), 3)}`;
 			console.log(`${formattedDate} [ODC][${this.device.getCurrentDeviceConfig().host}] ${message}`, ...args);
 		}
 	}


### PR DESCRIPTION
This is caused because Date.getMonth() returns a 0-based month index. The fix is to add 1 for calendar month index.

Tested on a benjamin, OS-13.1