### PR TITLE
Add stoppable dependency and fix port bug in NetworkProxy

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,7 +19,8 @@
                 "path": "^0.12.7",
                 "portfinder": "^1.0.33",
                 "postman-request": "^2.88.1-postman.40",
-                "roku-deploy": "^3.10.2"
+                "roku-deploy": "^3.10.2",
+                "stoppable": "^1.1.0"
             },
             "devDependencies": {
                 "@rokucommunity/bslint": "^0.7.3",
@@ -5700,6 +5701,16 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/stoppable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4",
+                "npm": ">=6"
+            }
+        },
         "node_modules/stream-length": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/stream-length/-/stream-length-1.0.2.tgz",
@@ -10949,6 +10960,11 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
             "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+        },
+        "stoppable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
         },
         "stream-length": {
             "version": "1.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -40,7 +40,8 @@
         "path": "^0.12.7",
         "portfinder": "^1.0.33",
         "postman-request": "^2.88.1-postman.40",
-        "roku-deploy": "^3.10.2"
+        "roku-deploy": "^3.10.2",
+        "stoppable": "^1.1.0"
     },
     "devDependencies": {
         "@rokucommunity/bslint": "^0.7.3",

--- a/client/scripts/buildRelease.ts
+++ b/client/scripts/buildRelease.ts
@@ -55,7 +55,7 @@ if (argv[2] === '--dev') {
 	} else if (argv[2] === '--alpha') {
 		options = '--tag alpha';
 	}
-	output = execSync(`npm publish ${options} ${outputFolder}`, {
+	output = execSync(`npm publish ${options} '${outputFolder}'`, {
 		encoding: 'utf8'
 	});
 }

--- a/client/src/NetworkProxy.spec.ts
+++ b/client/src/NetworkProxy.spec.ts
@@ -65,7 +65,6 @@ describe('NetworkProxy', function () {
 
 	it('should be able to intercept a request off device', async () => {
 		const originalRequestBody = {original: true};
-
 		const testUrl = `http://127.0.0.1:${testServerPort}/test?key=value`;
 
 		const removeCallback = proxy.addCallback({
@@ -101,6 +100,7 @@ describe('NetworkProxy', function () {
 
 		const promise = needle('post', `http://127.0.0.1:${proxyPort}/;${testUrl}`, JSON.stringify(originalRequestBody), options);
 		const response = await utils.promiseTimeout(promise, 2000, 'Did not receive proxy request');
+
 		expect(response.body.received).to.be.true;
 		expect(response.body.overrideResponse).to.be.true;
 		removeCallback();


### PR DESCRIPTION
We are using stoppable to avoid getting in a state where a request is still pending but we are done with our test and can't end the script because the server is still running.