### PR TITLE
First step in moving away from storeNodeReferences in favor of using Roku's app-ui API instead

### DIFF
--- a/client/.vscode/launch.json
+++ b/client/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"cwd": "${workspaceFolder}",
 			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
 			"args": ["--bail", "./dist/ECP.spec.js", "./dist/utils.spec.js"],
-			"console": "integratedTerminal",
+			"console": "internalConsole",
 			"internalConsoleOptions": "neverOpen"
 		}, {
 			"name": "Debug Device Tests",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "roku-test-automation",
-    "version": "2.2.0",
+    "version": "2.2.0-1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "roku-test-automation",
-            "version": "2.2.0",
+            "version": "2.2.0-1",
             "license": "MIT",
             "dependencies": {
                 "@suitest/types": "^4.6.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "roku-test-automation",
-    "version": "2.1.0-0",
+    "version": "2.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "roku-test-automation",
-            "version": "2.1.0-0",
+            "version": "2.2.0",
             "license": "MIT",
             "dependencies": {
                 "@suitest/types": "^4.6.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "roku-test-automation",
-    "version": "2.2.0-1",
+    "version": "2.2.0-3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "roku-test-automation",
-            "version": "2.2.0-1",
+            "version": "2.2.0-3",
             "license": "MIT",
             "dependencies": {
                 "@suitest/types": "^4.6.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roku-test-automation",
-    "version": "2.2.0-1",
+    "version": "2.2.0-3",
     "description": "Helps with automating functional tests",
     "main": "client/dist/index.js",
     "typings": "client/dist/index.d.ts",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roku-test-automation",
-    "version": "2.1.0-0",
+    "version": "2.2.0",
     "description": "Helps with automating functional tests",
     "main": "client/dist/index.js",
     "typings": "client/dist/index.d.ts",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roku-test-automation",
-    "version": "2.2.0",
+    "version": "2.2.0-1",
     "description": "Helps with automating functional tests",
     "main": "client/dist/index.js",
     "typings": "client/dist/index.d.ts",

--- a/client/rta-config.schema.json
+++ b/client/rta-config.schema.json
@@ -54,6 +54,7 @@
                 "defaultBase": {
                     "description": "Allows specifying the default base that will be used if one was not provided in the args for a request",
                     "enum": [
+                        "elementId",
                         "focusedNode",
                         "global",
                         "nodeRef",

--- a/client/rta-config.schema.json
+++ b/client/rta-config.schema.json
@@ -54,6 +54,7 @@
                 "defaultBase": {
                     "description": "Allows specifying the default base that will be used if one was not provided in the args for a request",
                     "enum": [
+                        "appUI",
                         "elementId",
                         "focusedNode",
                         "global",

--- a/client/src/ECP.spec.ts
+++ b/client/src/ECP.spec.ts
@@ -13,7 +13,6 @@ import { ECP } from './ECP';
 import * as testUtils from './test/utils';
 import type { ConfigOptions } from './types/ConfigOptions';
 import type { AppUIResponse, AppUIResponseChild } from '.';
-import { utils } from '.';
 
 describe('ECP', function () {
 	let ecp: ECP;
@@ -29,9 +28,17 @@ describe('ECP', function () {
 			},
 			sendEcpGet: () => {
 				return ecpResponse;
+			},
+			setConfig: (config) => { }
+		};
+
+		config = {
+			RokuDevice: {
+				devices: []
 			}
 		};
-		ecp = new ECP(device);
+
+		ecp = new ECP(device, config);
 		ecpUtils = ecp['utils'];
 		ecpResponse = '';
 	});
@@ -42,7 +49,7 @@ describe('ECP', function () {
 
 	describe('sendText', function () {
 		it('calls_device_sendEcpPost_for_each_character', async () => {
-			const stub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {}) as any);
+			const stub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => { }) as any);
 
 			const text = 'love my life';
 			await ecp.sendText(text);
@@ -52,16 +59,16 @@ describe('ECP', function () {
 		it('uses_raspTemplateVariable_if_provided_instead_of_text_for_rasp_output', async () => {
 			ecp.startRaspFileCreation();
 			const raspFileSteps = (ecp as any).raspFileSteps as string[];
-			await ecp.sendText('bob@hotmail.com', {raspTemplateVariable: 'script-login'});
+			await ecp.sendText('bob@hotmail.com', { raspTemplateVariable: 'script-login' });
 			expect(raspFileSteps[0]).to.contain('script-login');
-			await ecp.sendText('123456', {raspTemplateVariable: 'script-password'});
+			await ecp.sendText('123456', { raspTemplateVariable: 'script-password' });
 			expect(raspFileSteps[1]).to.contain('script-password');
 		});
 	});
 
 	describe('sendKeypressSequence', function () {
 		it('calls_device_sendEcpPost_for_each_key', async () => {
-			const stub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {}) as any);
+			const stub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => { }) as any);
 
 			const keys = [ECP.Key.Forward, ECP.Key.Play, ECP.Key.Rewind];
 			await ecp.sendKeypressSequence(keys);
@@ -81,16 +88,16 @@ describe('ECP', function () {
 				}
 			}) as any);
 
-			await ecp.sendKeypressSequence(keys, {count: count});
+			await ecp.sendKeypressSequence(keys, { count: count });
 			expect(stub.callCount).to.equal(keys.length * count);
 		});
 
 		it('should_not_send_any_keys_if_count_is_zero', async () => {
 			const keys = [ECP.Key.Forward, ECP.Key.Play, ECP.Key.Rewind];
 
-			const stub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => {}) as any);
+			const stub = sinon.stub(device, 'sendEcpPost').callsFake(((path: string, params?: object, body?: needle.BodyData) => { }) as any);
 
-			await ecp.sendKeypressSequence(keys, {count: 0});
+			await ecp.sendKeypressSequence(keys, { count: 0 });
 			expect(stub.callCount).to.equal(0);
 		});
 	});
@@ -109,7 +116,7 @@ describe('ECP', function () {
 		});
 
 		it('does_not_sleep_if_not_requested', async () => {
-			const stub = sinon.stub(ecpUtils, 'sleep').callsFake(((milliseconds: number) => {}) as any);
+			const stub = sinon.stub(ecpUtils, 'sleep').callsFake(((milliseconds: number) => { }) as any);
 
 			await ecp.sendKeypress(ECP.Key.Home, 0);
 
@@ -325,7 +332,7 @@ describe('ECP', function () {
 		});
 
 		it('should_throw_if_launch_not_successful_and_verification_is_enabled', async () => {
-			sinon.stub(ecpUtils, 'sleep').callsFake(((milliseconds: number) => {}) as any);
+			sinon.stub(ecpUtils, 'sleep').callsFake(((milliseconds: number) => { }) as any);
 			try {
 				await ecp.sendLaunchChannel({
 					channelId: 'dev',
@@ -503,7 +510,7 @@ describe('ECP', function () {
 		const outputPath = 'test-path.rasp';
 
 		it('outputs_file_at_path_specified_with_correct_contents', async () => {
-			sinon.stub(ecpUtils, 'sleep').callsFake(((milliseconds: number) => {}) as any);
+			sinon.stub(ecpUtils, 'sleep').callsFake(((milliseconds: number) => { }) as any);
 			config.ECP = {
 				default: {
 					keypressDelay: 1500
@@ -523,7 +530,7 @@ describe('ECP', function () {
 			await ecp.sendKeypress(ecp.Key.Ok, 1);
 			ecp.finishRaspFileCreation(outputPath);
 			const expectedContents =
-`params:
+				`params:
     rasp_version: 1
     default_keypress_wait: 1.5
 steps:
@@ -549,6 +556,99 @@ steps:
 		});
 		after(() => {
 			fsExtra.removeSync(outputPath);
+		});
+	});
+
+	describe('getAppUI', function () {
+		let appUIResponse: AppUIResponse;
+
+		beforeEach(async () => {
+			ecpResponse = await testUtils.getNeedleMockResponse('ECP/getAppUI/appUIResponse');
+		});
+
+		it('Should add the sceneBoundingRects for scene', async () => {
+			appUIResponse = await ecp.getAppUI();
+
+			expect(appUIResponse.screen.children[0].sceneRect).to.haveOwnProperty('x');
+			expect(appUIResponse.screen.children[0].sceneRect).to.haveOwnProperty('y');
+			expect(appUIResponse.screen.children[0].sceneRect).to.haveOwnProperty('width');
+			expect(appUIResponse.screen.children[0].sceneRect).to.haveOwnProperty('height');
+		});
+
+		it('Should add the sceneBoundingRects for scene\'s children\'s children', async () => {
+			appUIResponse = await ecp.getAppUI();
+
+			for (const child of appUIResponse.screen?.children?.[0]?.children?.[4]?.children || []) {
+				expect(child.sceneRect).to.haveOwnProperty('x');
+				expect(child.sceneRect).to.haveOwnProperty('y');
+				expect(child.sceneRect).to.haveOwnProperty('width');
+				expect(child.sceneRect).to.haveOwnProperty('height');
+			}
+		});
+
+		it('should not return a key path for RowListItem or internal MarkupGrid but should still create the correct key path for its children', async () => {
+			appUIResponse = await ecp.getAppUI();
+			const row1 = appUIResponse.screen?.children?.[0]?.children?.[4]?.children?.[0]?.children?.[7]?.children?.[0];
+			expect(row1?.subtype).to.equal('RowListItem');
+			expect(row1?.keyPath).to.be.undefined;
+
+			const row1TitleComponent = row1?.children?.[0];
+			expect(row1TitleComponent?.subtype).to.equal('Label');
+			expect(row1TitleComponent?.keyPath).to.equal('#pagesContainerGroup.0.#rowListWithoutCustomTitleComponent.0.title');
+
+			const row1FirstItem = row1?.children?.[2]?.children?.[0];
+			expect(row1FirstItem?.subtype).to.equal('RowListItemComponent');
+			expect(row1FirstItem?.keyPath).to.equal('#pagesContainerGroup.0.#rowListWithoutCustomTitleComponent.0.items.0');
+		});
+
+		it('should return correct position for a node with offset bounds due to children', async () => {
+			appUIResponse = await ecp.getAppUI();
+			const rect3 = appUIResponse.screen?.children?.[0]?.children?.[4]?.children?.[0].children?.[2].children?.[0];
+			expect(rect3?.keyPath).to.equal('#pagesContainerGroup.0.#rect2.#rect3');
+			expect(rect3?.sceneRect?.height).to.equal(50);
+			expect(rect3?.sceneRect?.width).to.equal(50);
+			expect(rect3?.sceneRect?.x).to.equal(125);
+			expect(rect3?.sceneRect?.y).to.equal(125);
+		});
+
+		it('should return correct position for a node with offset bounds due to children', async () => {
+			appUIResponse = await ecp.getAppUI();
+			const offsetGroup = appUIResponse.screen?.children?.[0]?.children?.[4]?.children?.[0].children?.[3];
+			expect(offsetGroup?.keyPath).to.equal('#pagesContainerGroup.0.#offsetGroup');
+			expect(offsetGroup?.sceneRect?.height).to.equal(100);
+			expect(offsetGroup?.sceneRect?.width).to.equal(300);
+			expect(offsetGroup?.sceneRect?.x).to.equal(1600);
+			expect(offsetGroup?.sceneRect?.y).to.equal(200);
+		});
+
+		it('should return correct position for a RowList item', async () => {
+			appUIResponse = await ecp.getAppUI();
+			const rowListItemComponent0 = appUIResponse.screen?.children?.[0]?.children?.[4]?.children?.[0]?.children?.[7]?.children?.[0].children?.[2].children?.[0];
+			expect(rowListItemComponent0?.keyPath).to.equal('#pagesContainerGroup.0.#rowListWithoutCustomTitleComponent.0.items.0');
+			expect(rowListItemComponent0?.sceneRect?.height).to.equal(150);
+			expect(rowListItemComponent0?.sceneRect?.width).to.equal(300);
+			expect(rowListItemComponent0?.sceneRect?.x).to.equal(150);
+			expect(rowListItemComponent0?.sceneRect?.y).to.equal(336);
+		});
+
+		it('should return correct position for the second row RowList item', async () => {
+			appUIResponse = await ecp.getAppUI();
+			const rowListItemComponent1_0 = appUIResponse.screen?.children?.[0]?.children?.[4]?.children?.[0]?.children?.[7]?.children?.[1].children?.[2].children?.[0];
+			expect(rowListItemComponent1_0?.keyPath).to.equal('#pagesContainerGroup.0.#rowListWithoutCustomTitleComponent.1.items.0');
+			expect(rowListItemComponent1_0?.sceneRect?.height).to.equal(150);
+			expect(rowListItemComponent1_0?.sceneRect?.width).to.equal(300);
+			expect(rowListItemComponent1_0?.sceneRect?.x).to.equal(150);
+			expect(rowListItemComponent1_0?.sceneRect?.y).to.equal(536);
+		});
+
+		it('should return correct position for a custom row title element', async () => {
+			appUIResponse = await ecp.getAppUI();
+			const rowListCustomRowTitle0 = appUIResponse.screen?.children?.[0]?.children?.[4]?.children?.[0]?.children?.[8]?.children?.[0].children?.[0].children?.[0];
+			expect(rowListCustomRowTitle0?.keyPath).to.equal('#pagesContainerGroup.0.#rowListWithCustomTitleComponent.0.title');
+			expect(rowListCustomRowTitle0?.sceneRect?.height).to.equal(36);
+			expect(rowListCustomRowTitle0?.sceneRect?.width).to.equal(201);
+			expect(rowListCustomRowTitle0?.sceneRect?.x).to.equal(150);
+			expect(rowListCustomRowTitle0?.sceneRect?.y).to.equal(700);
 		});
 	});
 });

--- a/client/src/ECP.spec.ts
+++ b/client/src/ECP.spec.ts
@@ -10,8 +10,10 @@ const sinon = sinonImport.createSandbox();
 const expect = chai.expect;
 
 import { ECP } from './ECP';
-import * as utils from './test/utils';
+import * as testUtils from './test/utils';
 import type { ConfigOptions } from './types/ConfigOptions';
+import type { AppUIResponse, AppUIResponseChild } from '.';
+import { utils } from '.';
 
 describe('ECP', function () {
 	let ecp: ECP;
@@ -29,13 +31,7 @@ describe('ECP', function () {
 				return ecpResponse;
 			}
 		};
-		config = {
-			RokuDevice: {
-				devices: []
-			}
-		};
-		ecp = new ECP(config);
-		ecp['device'] = device;
+		ecp = new ECP(device);
 		ecpUtils = ecp['utils'];
 		ecpResponse = '';
 	});
@@ -248,7 +244,7 @@ describe('ECP', function () {
 
 	describe('getActiveApp', function () {
 		it('app_active', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getActiveApp();
 			expect(result.app?.id).to.equal('dev');
 			expect(result.app?.title).to.equal('mockAppTitle');
@@ -257,14 +253,14 @@ describe('ECP', function () {
 		});
 
 		it('no_app_or_screensaver_active', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getActiveApp();
 			expect(result.app?.id).to.not.be.ok;
 			expect(result.app?.title).to.equal('Roku');
 		});
 
 		it('screensaver_active_app_open', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getActiveApp();
 			expect(result.app?.id).to.equal('dev');
 			expect(result.app?.title).to.equal('mockAppTitle');
@@ -278,7 +274,7 @@ describe('ECP', function () {
 		});
 
 		it('screensaver_active_no_app_open', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getActiveApp();
 			expect(result.screensaver?.id).to.equal('261525');
 			expect(result.screensaver?.title).to.equal('Aquatic Life');
@@ -292,7 +288,7 @@ describe('ECP', function () {
 
 	describe('sendLaunchChannel', function () {
 		it('should_not_throw_if_successful_and_verification_is_enabled', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			await ecp.sendLaunchChannel({
 				channelId: 'dev',
 				params: {},
@@ -355,7 +351,7 @@ describe('ECP', function () {
 
 	describe('getMediaPlayer', function () {
 		it('app_closed', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getMediaPlayer();
 			expect(result.state).to.equal('close');
 			expect(result.error).to.equal(false);
@@ -363,7 +359,7 @@ describe('ECP', function () {
 		});
 
 		it('player_closed', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getMediaPlayer();
 
 			expect(result.state).to.equal('close');
@@ -375,7 +371,7 @@ describe('ECP', function () {
 		});
 
 		it('player_startup', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getMediaPlayer();
 
 			expect(result.state).to.equal('startup');
@@ -397,7 +393,7 @@ describe('ECP', function () {
 		});
 
 		it('player_buffering', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getMediaPlayer();
 
 			expect(result.state).to.equal('buffer');
@@ -419,7 +415,7 @@ describe('ECP', function () {
 		});
 
 		it('player_playing', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getMediaPlayer();
 
 			expect(result.state).to.equal('play');
@@ -447,7 +443,7 @@ describe('ECP', function () {
 		});
 
 		it('player_paused', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getMediaPlayer();
 
 			expect(result.state).to.equal('pause');
@@ -477,7 +473,7 @@ describe('ECP', function () {
 
 	describe('getChanperf', function () {
 		it('app_closed', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getChanperf();
 			expect(result.error).to.equal('Channel not running');
 			expect(result.status).to.equal('FAILED');
@@ -485,7 +481,7 @@ describe('ECP', function () {
 		});
 
 		it('app_open', async () => {
-			ecpResponse = await utils.getNeedleMockResponse(this);
+			ecpResponse = await testUtils.getNeedleMockResponse(this);
 			const result = await ecp.getChanperf();
 			expect(result.status).to.equal('OK');
 			expect(result.plugin?.id).to.equal('dev');

--- a/client/src/ECP.ts
+++ b/client/src/ECP.ts
@@ -404,7 +404,7 @@ export class ECP {
 						} else {
 							if (markupGrid.translation) {
 								childOffset = [
-									childOffset[0] - markupGrid.translation[0],
+									childOffset[0],
 									childOffset[1] - markupGrid.translation[1]
 								];
 							}
@@ -412,15 +412,23 @@ export class ECP {
 					}
 
 					childOffset = [
-						node.bounds[0] + childOffset[0],
+						childOffset[0],
 						node.bounds[1] + childOffset[1]
 					];
 				}
 			} else if (node.translation && (node.subtype !== 'MarkupGrid' || parent?.subtype !== 'RowListItem')) {
-				childOffset = [
-					node.translation[0] + childOffset[0],
-					node.translation[1] + childOffset[1]
-				];
+				// We have to add to offsets from bounds values for correct positioning of MarkupGrid children
+				if (parent?.subtype === 'MarkupGrid' && node.bounds) {
+					childOffset = [
+						node.bounds[0] + childOffset[0],
+						node.bounds[1] + childOffset[1]
+					];
+				} else {
+					childOffset = [
+						node.translation[0] + childOffset[0],
+						node.translation[1] + childOffset[1]
+					];
+				}
 			}
 
 			this.calculateSceneBoundingRects(child, node, childOffset);

--- a/client/src/ECP.ts
+++ b/client/src/ECP.ts
@@ -1,5 +1,5 @@
 import type { HttpRequestOptions } from './RokuDevice';
-import type { RokuDevice } from './RokuDevice';
+import { RokuDevice } from './RokuDevice';
 import type { ActiveAppResponse } from './types/ActiveAppResponse';
 import type { ConfigOptions } from './types/ConfigOptions';
 import { utils } from './utils';
@@ -38,7 +38,17 @@ export class ECP {
 	public static readonly Key = Key;
 	public readonly Key = Key;
 
-	constructor(device: RokuDevice, config?: ConfigOptions) {
+	/**
+	 * For the remainder of 2.X, device can either be a RokuDevice instance or a config object for backwards compability but will be removed in 3.0
+	 */
+	constructor(device?: RokuDevice | ConfigOptions, config?: ConfigOptions) {
+		if (!device) {
+			device = new RokuDevice();
+		} else if (!(device instanceof RokuDevice)) {
+			config = device;
+			device = new RokuDevice();
+		}
+
 		this.device = device;
 		if (config) {
 			this.setConfig(config);
@@ -259,7 +269,7 @@ export class ECP {
 					if (await this.isActiveApp(channelId)) {
 						return;
 					}
-				} catch (e) {}
+				} catch (e) { }
 				await this.utils.sleep(100);
 			}
 			throw this.utils.makeError('sendLaunchChannelVerifyLaunch', `Could not launch channel with id of '${channelId}`);

--- a/client/src/ECP.ts
+++ b/client/src/ECP.ts
@@ -322,7 +322,6 @@ export class ECP {
 		return response;
 	}
 
-
 	private convertChildrenForGetAppUI(children: any[], parentIsRowListItem = false) {
 		const response: AppUIResponseChild[] = [];
 
@@ -471,9 +470,9 @@ export class ECP {
 			} else if (node.subtype === 'MarkupGrid') {
 				currentNodeKeyPathParts.push('items');
 			}
-		} else if (node.id && !keyPathContext.duplicateIdsFound) {
+		} else if (addKeyPath && node.id && !keyPathContext.duplicateIdsFound) {
 			currentNodeKeyPathParts.push(`#${node.id}`);
-		} else {
+		} else if (addKeyPath) {
 			currentNodeKeyPathParts.push(keyPathContext.position.toString());
 		}
 

--- a/client/src/OnDeviceComponent.ts
+++ b/client/src/OnDeviceComponent.ts
@@ -401,6 +401,13 @@ export class OnDeviceComponent {
 		return output;
 	}
 
+	public async assignElementIdOnAllNodes(args: ODC.AssignElementIdOnAllNodesArgs = {}, options: ODC.RequestOptions = {}) {
+		const result = await this.sendRequest(ODC.RequestType.assignElementIdOnAllNodes, {...args, convertResponseToJsonCompatible: false}, options);
+		const output = result.json as ODC.AssignElementIdOnAllNodesResponse;
+
+		return output;
+	}
+
 	private buildKeyPathsRecursively(nodeTrees: ODC.TreeNode[], keyPathParts = [] as string[], parentIsRowlistItem = false, parentIsTitleGroup = false) {
 		for (const nodeTree of nodeTrees) {
 			let keyPathPostfix = '';

--- a/client/src/OnDeviceComponent.ts
+++ b/client/src/OnDeviceComponent.ts
@@ -1199,12 +1199,17 @@ export class OnDeviceComponent {
 	private async sendRequest(type: ODC.RequestType, args: ODC.RequestArgs, options: ODC.RequestOptions = {}, requestorCallback?: (response: ODC.RequestResponse) => Promise<boolean>) {
 		const requestId = utils.randomStringGenerator();
 
-		this.debugLog(`Sending request ${requestId} of type ${type} with args:`, args);
+		const sentArgs = { ...args };
+
+		// Remove any known args that we don't want to send to the device
+		delete sentArgs['appUIResponse'];
+
+		this.debugLog(`Sending request ${requestId} of type ${type} with args:`, sentArgs);
 
 		const request: ODC.Request = {
 			id: requestId,
 			type: type,
-			args: args,
+			args: sentArgs,
 			isRecuring: !!requestorCallback
 		};
 

--- a/client/src/OnDeviceComponent.ts
+++ b/client/src/OnDeviceComponent.ts
@@ -4,7 +4,7 @@ import type { RokuDevice } from './RokuDevice';
 import type { ConfigOptions } from './types/ConfigOptions';
 import { utils } from './utils';
 import * as ODC from './types/OnDeviceComponent';
-import type { AppUIResponse, AppUIResponseChild } from '.';
+import type { AppUIResponse, AppUIResponseChild } from './types/AppUIResponse';
 import { ecp } from '.';
 
 export class OnDeviceComponent {
@@ -12,7 +12,7 @@ export class OnDeviceComponent {
 	private defaultTimeout = 10000;
 	private requestHeaderSize = 8;
 	private storedDeviceRegistry?: {
-		[section: string]: {[sectionItemKey: string]: string}
+		[section: string]: { [sectionItemKey: string]: string }
 	};
 	private config?: ConfigOptions;
 	private activeRequests: { [key: string]: ODC.Request } = {};
@@ -195,14 +195,14 @@ export class OnDeviceComponent {
 	public async hasFocus(args: ODC.HasFocusArgs, options: ODC.RequestOptions = {}) {
 		await this.applySharedKeyPathLogic(args, options);
 
-		const result = await this.sendRequest(ODC.RequestType.hasFocus, {...args, convertResponseToJsonCompatible: false}, options);
+		const result = await this.sendRequest(ODC.RequestType.hasFocus, { ...args, convertResponseToJsonCompatible: false }, options);
 		return result.json.hasFocus as boolean;
 	}
 
 	public async isInFocusChain(args: ODC.IsInFocusChainArgs, options: ODC.RequestOptions = {}) {
 		await this.applySharedKeyPathLogic(args, options);
 
-		const result = await this.sendRequest(ODC.RequestType.isInFocusChain, {...args, convertResponseToJsonCompatible: false}, options);
+		const result = await this.sendRequest(ODC.RequestType.isInFocusChain, { ...args, convertResponseToJsonCompatible: false }, options);
 		return result.json.isInFocusChain as boolean;
 	}
 
@@ -222,7 +222,7 @@ export class OnDeviceComponent {
 				if (response.observerFired !== undefined) {
 					// TODO add in support for doing match checks here as well
 
-					await this.cancelRequest({id: response.id});
+					await this.cancelRequest({ id: response.id });
 
 					// After we cancel the request we return the response
 					resolve(response);
@@ -295,7 +295,7 @@ export class OnDeviceComponent {
 		//We return the cancel Observer Function to easily cancel the continuous observer
 		const cancelObserverFunc = async () => {
 			const requestId = result.json.id;
-			return await this.cancelRequest({id: requestId});
+			return await this.cancelRequest({ id: requestId });
 		};
 
 		return cancelObserverFunc;
@@ -330,7 +330,7 @@ export class OnDeviceComponent {
 	/** Needed to convert appUI key path to scene but might be useful in other cases as well. Takes in a key path and will try and call getParent() on each node in the tree until it gets to the Scene */
 	public async convertKeyPathToSceneKeyPath(args: ODC.ConvertKeyPathToSceneKeyPathArgs, options: ODC.RequestOptions = {}) {
 		// Prevents changes made for this function from affecting the original args object
-		args = { ... args };
+		args = { ...args };
 
 		// We are handling the appUI conversion ourselves to handle it separately
 		if (args.base === 'appUI' && args.keyPath) {
@@ -361,7 +361,7 @@ export class OnDeviceComponent {
 							keyPath: args.keyPath,
 							timeTaken: 0,
 							id: ''
-						} as {base: 'scene'; keyPath: string;} & ODC.ReturnTimeTaken);
+						} as { base: 'scene'; keyPath: string; } & ODC.ReturnTimeTaken);
 					} else {
 						if (remainingKeyPathPart) {
 							// Check if remainingKeyPathPart starts with #
@@ -372,7 +372,7 @@ export class OnDeviceComponent {
 										arrayGridChild = child;
 									}
 								}
-							} if(arrayGridChild?.children?.[+remainingKeyPathPart]) {
+							} if (arrayGridChild?.children?.[+remainingKeyPathPart]) {
 								arrayGridChild = arrayGridChild.children[+remainingKeyPathPart];
 							}
 						}
@@ -435,7 +435,7 @@ export class OnDeviceComponent {
 						await this.assignElementIdOnAllNodes();
 						appUIResponse = await ecp.getAppUI();
 						break;
-					} catch(e) {
+					} catch (e) {
 						if (Date.now() - startTime > timeout) {
 							throw e;
 						}
@@ -558,24 +558,24 @@ export class OnDeviceComponent {
 	}
 
 	public async getAllCount(args: ODC.GetRootsCountArgs = {}, options: ODC.RequestOptions = {}) {
-		const result = await this.sendRequest(ODC.RequestType.getAllCount, {...args, convertResponseToJsonCompatible: false}, options);
+		const result = await this.sendRequest(ODC.RequestType.getAllCount, { ...args, convertResponseToJsonCompatible: false }, options);
 		return result.json as {
 			totalNodes: number;
-			nodeCountByType: {[key: string]: number}
+			nodeCountByType: { [key: string]: number }
 		} & ODC.ReturnTimeTaken;
 	}
 
 	public async getRootsCount(args: ODC.GetRootsCountArgs = {}, options: ODC.RequestOptions = {}) {
-		const result = await this.sendRequest(ODC.RequestType.getRootsCount, {...args, convertResponseToJsonCompatible: false}, options);
+		const result = await this.sendRequest(ODC.RequestType.getRootsCount, { ...args, convertResponseToJsonCompatible: false }, options);
 		return result.json as {
 			totalNodes: number;
-			nodeCountByType: {[key: string]: number}
+			nodeCountByType: { [key: string]: number }
 		} & ODC.ReturnTimeTaken;
 	}
 
 	public async storeNodeReferences(args: ODC.StoreNodeReferencesArgs = {}, options: ODC.RequestOptions = {}) {
 		await this.applySharedKeyPathLogic(args, options);
-		const result = await this.sendRequest(ODC.RequestType.storeNodeReferences, {...args, convertResponseToJsonCompatible: false}, options);
+		const result = await this.sendRequest(ODC.RequestType.storeNodeReferences, { ...args, convertResponseToJsonCompatible: false }, options);
 		const output = result.json as ODC.StoreNodeReferencesResponse;
 
 		const rootTree = [] as ODC.TreeNode[];
@@ -650,7 +650,7 @@ export class OnDeviceComponent {
 	}
 
 	public async assignElementIdOnAllNodes(args: ODC.AssignElementIdOnAllNodesArgs = {}, options: ODC.RequestOptions = {}) {
-		const result = await this.sendRequest(ODC.RequestType.assignElementIdOnAllNodes, {...args, convertResponseToJsonCompatible: false}, options);
+		const result = await this.sendRequest(ODC.RequestType.assignElementIdOnAllNodes, { ...args, convertResponseToJsonCompatible: false }, options);
 		const output = result.json as ODC.AssignElementIdOnAllNodesResponse;
 
 		return output;
@@ -685,7 +685,7 @@ export class OnDeviceComponent {
 				} else {
 					console.log('Encountered unexpected subtype ' + nodeTree.subtype);
 				}
-			} else if(parentIsTitleGroup) {
+			} else if (parentIsTitleGroup) {
 				// We don't want to append to currentNodeTreeKeyPathParts in this case
 			} else if (nodeTree.id) {
 				currentNodeTreeKeyPathParts.push('#' + nodeTree.id);
@@ -700,9 +700,9 @@ export class OnDeviceComponent {
 	}
 
 	public async deleteNodeReferences(args: ODC.DeleteNodeReferencesArgs = {}, options: ODC.RequestOptions = {}) {
-			await this.applySharedKeyPathLogic(args, options);
+		await this.applySharedKeyPathLogic(args, options);
 
-		const result = await this.sendRequest(ODC.RequestType.deleteNodeReferences, {...args, convertResponseToJsonCompatible: false}, options);
+		const result = await this.sendRequest(ODC.RequestType.deleteNodeReferences, { ...args, convertResponseToJsonCompatible: false }, options);
 		return result.json as ODC.ReturnTimeTaken;
 	}
 
@@ -833,13 +833,17 @@ export class OnDeviceComponent {
 		return nodeFound;
 	}
 
-	/** deprecated will be removed in 3.0 */
+	/**
+	 * @deprecated will be removed in 3.0
+	 */
 	public async startResponsivenessTesting(args: ODC.StartResponsivenessTestingArgs = {}, options: ODC.RequestOptions = {}) {
 		const result = await this.sendRequest(ODC.RequestType.startResponsivenessTesting, args, options);
 		return result.json as ODC.ReturnTimeTaken;
 	}
 
-	/** deprecated will be removed in 3.0 */
+	/**
+	 * @deprecated will be removed in 3.0
+	 */
 	public async getResponsivenessTestingData(args = {}, options: ODC.RequestOptions = {}) {
 		const result = await this.sendRequest(ODC.RequestType.getResponsivenessTestingData, args, options);
 		return result.json as ODC.ReturnTimeTaken & {
@@ -869,7 +873,9 @@ export class OnDeviceComponent {
 		};
 	}
 
-	/** deprecated will be removed in 3.0 */
+	/**
+	 * @deprecated will be removed in 3.0
+	 */
 	public async stopResponsivenessTesting(args = {}, options: ODC.RequestOptions = {}) {
 		const result = await this.sendRequest(ODC.RequestType.stopResponsivenessTesting, args, options);
 		return result.json as ODC.ReturnTimeTaken;
@@ -915,17 +921,17 @@ export class OnDeviceComponent {
 
 	public async isSubtype(args: ODC.IsSubtypeArgs, options: ODC.RequestOptions = {}) {
 		await this.applySharedKeyPathLogic(args, options);
-		const result = await this.sendRequest(ODC.RequestType.isSubtype, {...args, convertResponseToJsonCompatible: false}, options);
+		const result = await this.sendRequest(ODC.RequestType.isSubtype, { ...args, convertResponseToJsonCompatible: false }, options);
 		return result.json.isSubtype as boolean;
 	}
 	//#endregion
 
 	//#region requests run on task thread
 	public async readRegistry(args: ODC.ReadRegistryArgs = {}, options: ODC.RequestOptions = {}) {
-		const result = await this.sendRequest(ODC.RequestType.readRegistry, {...args, convertResponseToJsonCompatible: false}, options);
+		const result = await this.sendRequest(ODC.RequestType.readRegistry, { ...args, convertResponseToJsonCompatible: false }, options);
 		return result.json as {
 			values: {
-				[section: string]: {[sectionItemKey: string]: string}
+				[section: string]: { [sectionItemKey: string]: string }
 			}
 		} & ODC.ReturnTimeTaken;
 	}
@@ -1051,7 +1057,7 @@ export class OnDeviceComponent {
 
 		if (args.field === undefined) {
 			const keyPathParts = args.keyPath.split('.');
-			return {...args, field: keyPathParts.pop(), keyPath: keyPathParts.join('.')};
+			return { ...args, field: keyPathParts.pop(), keyPath: keyPathParts.join('.') };
 		}
 
 		return args;
@@ -1293,7 +1299,7 @@ export class OnDeviceComponent {
 						error.message = `${json?.error?.message}`;
 						reject(error);
 					}
-				} catch(e) {
+				} catch (e) {
 					reject(e);
 				}
 			};
@@ -1302,7 +1308,7 @@ export class OnDeviceComponent {
 		const timeout = this.getTimeOut(options);
 		try {
 			return await utils.promiseTimeout(promise, timeout);
-		} catch(e) {
+		} catch (e) {
 			if ((e as Error).name === 'Timeout') {
 				let message = `${request.type} request timed out after ${timeout}ms`;
 

--- a/client/src/OnDeviceComponent.ts
+++ b/client/src/OnDeviceComponent.ts
@@ -355,7 +355,13 @@ export class OnDeviceComponent {
 
 						arrayGridChild = arrayGridChild.children[arrayGridChild.children.length - 1];
 					} else if (remainingKeyPathPart === 'title') {
-						// TODO add me
+						// For time being just changing base. Will not always work correctly but existing code does not either
+						return Promise.resolve({
+							base: 'scene',
+							keyPath: args.keyPath,
+							timeTaken: 0,
+							id: ''
+						} as {base: 'scene'; keyPath: string;} & ODC.ReturnTimeTaken);
 					} else {
 						if (remainingKeyPathPart) {
 							// Check if remainingKeyPathPart starts with #
@@ -392,7 +398,7 @@ export class OnDeviceComponent {
 
 		const result = await this.sendRequest(ODC.RequestType.convertKeyPathToSceneKeyPath, args, options);
 		return result.json as {
-			base?: 'scene';
+			base: 'scene';
 			keyPath: string;
 		} & ODC.ReturnTimeTaken;
 	}

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,13 +1,13 @@
 import { utils } from './utils';
 export { utils };
 
-import { ECP } from './ECP';
-const ecp = new ECP();
-export { ECP, ecp };
-
 import { RokuDevice } from './RokuDevice';
 const device = new RokuDevice();
 export { RokuDevice, device };
+
+import { ECP } from './ECP';
+const ecp = new ECP(device);
+export { ECP, ecp };
 
 import { OnDeviceComponent } from './OnDeviceComponent';
 const odc = new OnDeviceComponent(device);
@@ -21,6 +21,7 @@ import { Suitest } from './Suitest';
 const suitest = new Suitest(ecp, odc);
 export { Suitest, suitest };
 
+export * from './types/AppUIResponse';
 export * from './types/ActiveAppResponse';
 export * from './types/ConfigOptions';
 export * from './types/OnDeviceComponent';

--- a/client/src/test/mocks/ECP/getAppUI/appUIResponse.json
+++ b/client/src/test/mocks/ECP/getAppUI/appUIResponse.json
@@ -41,7 +41,7 @@
 								"focusable": "true",
 								"rcid": "0",
 								"uiElementId": "RTA_1",
-								"bounds": "{0, 0, 2192, 1222}"
+								"bounds": "{0, 0, 2085, 1115}"
 							},
 							"children": [
 								{
@@ -51,7 +51,7 @@
 										"rcid": "0",
 										"inheritParentTransform": "false",
 										"inheritParentOpacity": "false",
-										"bounds": "{0, 0, 1920, 1080}",
+										"bounds": "{0, 0, 1280, 720}",
 										"uri": "/RokuOS/Artwork/SceneGraph/GenevaTheme/Base/FHD/background.png",
 										"loadStatus": "3",
 										"index": "0"
@@ -103,7 +103,7 @@
 										"focused": "true",
 										"rcid": "0",
 										"uiElementId": "RTA_6",
-										"bounds": "{100, 100, 2092, 1122}",
+										"bounds": "{0, 0, 2085, 1115}",
 										"index": "1"
 									},
 									"children": [
@@ -111,13 +111,12 @@
 											"name": "LandingPage",
 											"value": "",
 											"attributes": {
-												"children": "9",
+												"children": "10",
 												"extends": "BasePage",
 												"focused": "true",
 												"rcid": "0",
 												"uiElementId": "RTA_11",
-												"translation": "{100, 100}",
-												"bounds": "{100, 100, 2092, 1122}",
+												"bounds": "{0, 0, 2085, 1115}",
 												"index": "0"
 											},
 											"children": [
@@ -177,6 +176,65 @@
 													]
 												},
 												{
+													"name": "RenderableNode",
+													"value": "",
+													"attributes": {
+														"children": "2",
+														"name": "offsetGroup",
+														"rcid": "0",
+														"uiElementId": "RTA_16",
+														"translation": "{1500, 100}",
+														"bounds": "{1600, 200, 300, 100}",
+														"index": "0"
+													},
+													"children": [
+														{
+															"name": "Rectangle",
+															"value": "",
+															"attributes": {
+																"name": "offsetGroupRect1",
+																"rcid": "0",
+																"uiElementId": "RTA_17",
+																"translation": "{100, 100}",
+																"bounds": "{100, 100, 100, 100}",
+																"color": "#ff0000ff",
+																"index": "0"
+															},
+															"children": []
+														},
+														{
+															"name": "Rectangle",
+															"value": "",
+															"attributes": {
+																"children": "1",
+																"name": "offsetGroupRect2",
+																"rcid": "0",
+																"uiElementId": "RTA_18",
+																"translation": "{300, 100}",
+																"bounds": "{300, 100, 100, 100}",
+																"color": "#00ff00ff",
+																"index": "1"
+															},
+															"children": [
+																{
+																	"name": "Rectangle",
+																	"value": "",
+																	"attributes": {
+																		"name": "offsetGroupRect2_child",
+																		"rcid": "0",
+																		"uiElementId": "RTA_19",
+																		"translation": "{25, 25}",
+																		"bounds": "{25, 25, 50, 50}",
+																		"color": "#0000ffff",
+																		"index": "0"
+																	},
+																	"children": []
+																}
+															]
+														}
+													]
+												},
+												{
 													"name": "AppButton",
 													"value": "",
 													"attributes": {
@@ -186,9 +244,9 @@
 														"focused": "true",
 														"focusable": "true",
 														"rcid": "0",
-														"uiElementId": "RTA_16",
+														"uiElementId": "RTA_20",
 														"translation": "{300, 150}",
-														"bounds": "{300, 150, 163, 96}",
+														"bounds": "{300, 150, 164, 96}",
 														"index": "0"
 													},
 													"children": [
@@ -197,8 +255,8 @@
 															"value": "",
 															"attributes": {
 																"rcid": "0",
-																"bounds": "{0, 0, 163, 96}",
-																"uri": "/RokuOS/Artwork/SceneGraph/GenevaTheme/Base/FHD/focus_list.9.png",
+																"bounds": "{0, 0, 164, 96}",
+																"uri": "/RokuOS/Artwork/SceneGraph/GenevaTheme/Base/HD/focus_list.9.png",
 																"loadStatus": "3",
 																"index": "0"
 															},
@@ -210,7 +268,7 @@
 															"attributes": {
 																"rcid": "0",
 																"visible": "false",
-																"uri": "/RokuOS/Artwork/SceneGraph/GenevaTheme/Base/FHD/focus_footprint.9.png",
+																"uri": "/RokuOS/Artwork/SceneGraph/GenevaTheme/Base/HD/focus_footprint.9.png",
 																"loadStatus": "3",
 																"index": "1"
 															},
@@ -222,9 +280,9 @@
 															"attributes": {
 																"rcid": "0",
 																"translation": "{36, 29}",
-																"bounds": "{36, 29, 91, 38}",
+																"bounds": "{36, 29, 92, 38}",
 																"text": "Login",
-																"color": "#121212ff",
+																"color": "#000000ff",
 																"index": "0"
 															},
 															"children": []
@@ -261,8 +319,8 @@
 														"children": "3",
 														"name": "testTarget",
 														"rcid": "0",
-														"uiElementId": "RTA_17",
-														"index": "0"
+														"uiElementId": "RTA_21",
+														"index": "1"
 													},
 													"children": [
 														{
@@ -271,7 +329,7 @@
 															"attributes": {
 																"name": "child1",
 																"rcid": "0",
-																"uiElementId": "RTA_18",
+																"uiElementId": "RTA_22",
 																"index": "0"
 															},
 															"children": []
@@ -283,7 +341,7 @@
 																"children": "3",
 																"name": "child2",
 																"rcid": "0",
-																"uiElementId": "RTA_19",
+																"uiElementId": "RTA_23",
 																"index": "1"
 															},
 															"children": [
@@ -293,7 +351,7 @@
 																	"attributes": {
 																		"name": "subchild1",
 																		"rcid": "0",
-																		"uiElementId": "RTA_20",
+																		"uiElementId": "RTA_24",
 																		"index": "0"
 																	},
 																	"children": []
@@ -304,7 +362,7 @@
 																	"attributes": {
 																		"name": "subchild2",
 																		"rcid": "0",
-																		"uiElementId": "RTA_21",
+																		"uiElementId": "RTA_25",
 																		"index": "1"
 																	},
 																	"children": []
@@ -315,7 +373,7 @@
 																	"attributes": {
 																		"name": "subchild3",
 																		"rcid": "0",
-																		"uiElementId": "RTA_22",
+																		"uiElementId": "RTA_26",
 																		"index": "2"
 																	},
 																	"children": []
@@ -328,7 +386,7 @@
 															"attributes": {
 																"name": "child3",
 																"rcid": "0",
-																"uiElementId": "RTA_23",
+																"uiElementId": "RTA_27",
 																"index": "2"
 															},
 															"children": []
@@ -341,7 +399,7 @@
 													"attributes": {
 														"name": "poster",
 														"rcid": "0",
-														"uiElementId": "RTA_24",
+														"uiElementId": "RTA_28",
 														"index": "0"
 													},
 													"children": []
@@ -353,9 +411,9 @@
 														"name": "rowListWithoutCustomTitleComponent",
 														"focusable": "true",
 														"rcid": "0",
-														"uiElementId": "RTA_25",
+														"uiElementId": "RTA_29",
 														"translation": "{150, 300}",
-														"bounds": "{128, 278, 1964, 444}",
+														"bounds": "{135, 285, 1950, 430}",
 														"children": "3",
 														"count": "2",
 														"focusItem": "0",
@@ -380,7 +438,7 @@
 																	"value": "",
 																	"attributes": {
 																		"rcid": "0",
-																		"bounds": "{0, 0, 87, 36}",
+																		"bounds": "{0, 0, 83, 36}",
 																		"text": "row 0",
 																		"color": "#ffffffff",
 																		"index": "0"
@@ -394,7 +452,7 @@
 																		"rcid": "0",
 																		"visible": "false",
 																		"opacity": "0",
-																		"translation": "{1838, 0}",
+																		"translation": "{1842, 0}",
 																		"text": "1 of 1",
 																		"color": "#ffffffff",
 																		"index": "1"
@@ -408,7 +466,7 @@
 																		"focusable": "true",
 																		"rcid": "0",
 																		"translation": "{0, 36}",
-																		"bounds": "{-22, 14, 1964, 194}",
+																		"bounds": "{-15, 21, 1950, 180}",
 																		"children": "3",
 																		"count": "1",
 																		"focusItem": "0",
@@ -423,7 +481,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_62",
+																				"uiElementId": "RTA_150",
 																				"index": "0",
 																				"focused": "true",
 																				"bounds": "{0, 0, 300, 150}"
@@ -435,7 +493,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_63",
+																						"uiElementId": "RTA_151",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -448,9 +506,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_64",
+																						"uiElementId": "RTA_152",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 205, 36}",
+																						"bounds": "{50, 25, 195, 36}",
 																						"text": "row 0  item 0",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -491,7 +549,7 @@
 																	"value": "",
 																	"attributes": {
 																		"rcid": "0",
-																		"bounds": "{0, 0, 82, 36}",
+																		"bounds": "{0, 0, 78, 36}",
 																		"text": "row 1",
 																		"color": "#ffffffff",
 																		"index": "0"
@@ -518,8 +576,8 @@
 																		"rcid": "0",
 																		"visible": "false",
 																		"translation": "{0, 36}",
-																		"children": "10",
-																		"count": "8",
+																		"children": "52",
+																		"count": "50",
 																		"focusItem": "0",
 																		"index": "0"
 																	},
@@ -532,7 +590,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_70",
+																				"uiElementId": "RTA_158",
 																				"bounds": "{0, 0, 300, 150}",
 																				"index": "0",
 																				"focused": "true"
@@ -544,7 +602,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_71",
+																						"uiElementId": "RTA_159",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -557,9 +615,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_72",
+																						"uiElementId": "RTA_160",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 200, 36}",
+																						"bounds": "{50, 25, 191, 36}",
 																						"text": "row 1  item 0",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -576,7 +634,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_73",
+																				"uiElementId": "RTA_161",
 																				"translation": "{330, 0}",
 																				"bounds": "{330, 0, 300, 150}",
 																				"index": "1"
@@ -588,7 +646,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_74",
+																						"uiElementId": "RTA_162",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -601,9 +659,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_75",
+																						"uiElementId": "RTA_163",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 195, 36}",
+																						"bounds": "{50, 25, 186, 36}",
 																						"text": "row 1  item 1",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -620,7 +678,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_76",
+																				"uiElementId": "RTA_164",
 																				"translation": "{660, 0}",
 																				"bounds": "{660, 0, 300, 150}",
 																				"index": "2"
@@ -632,7 +690,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_77",
+																						"uiElementId": "RTA_165",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -645,9 +703,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_78",
+																						"uiElementId": "RTA_166",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 198, 36}",
+																						"bounds": "{50, 25, 189, 36}",
 																						"text": "row 1  item 2",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -664,7 +722,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_79",
+																				"uiElementId": "RTA_167",
 																				"translation": "{990, 0}",
 																				"bounds": "{990, 0, 300, 150}",
 																				"index": "3"
@@ -676,7 +734,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_80",
+																						"uiElementId": "RTA_168",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -689,9 +747,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_81",
+																						"uiElementId": "RTA_169",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 3",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -708,7 +766,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_82",
+																				"uiElementId": "RTA_170",
 																				"translation": "{1320, 0}",
 																				"bounds": "{1320, 0, 300, 150}",
 																				"index": "4"
@@ -720,7 +778,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_83",
+																						"uiElementId": "RTA_171",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -733,9 +791,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_84",
+																						"uiElementId": "RTA_172",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 4",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -752,7 +810,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_85",
+																				"uiElementId": "RTA_173",
 																				"translation": "{1650, 0}",
 																				"bounds": "{1650, 0, 300, 150}",
 																				"index": "5"
@@ -764,7 +822,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_86",
+																						"uiElementId": "RTA_174",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -777,9 +835,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_87",
+																						"uiElementId": "RTA_175",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 5",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -809,7 +867,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_70",
+																				"uiElementId": "RTA_158",
 																				"bounds": "{0, 0, 300, 150}",
 																				"index": "0"
 																			},
@@ -820,7 +878,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_71",
+																						"uiElementId": "RTA_159",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -833,9 +891,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_72",
+																						"uiElementId": "RTA_160",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 200, 36}",
+																						"bounds": "{50, 25, 191, 36}",
 																						"text": "row 1  item 0",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -852,7 +910,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_73",
+																				"uiElementId": "RTA_161",
 																				"translation": "{330, 0}",
 																				"bounds": "{330, 0, 300, 150}",
 																				"index": "1"
@@ -864,7 +922,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_74",
+																						"uiElementId": "RTA_162",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -877,9 +935,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_75",
+																						"uiElementId": "RTA_163",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 195, 36}",
+																						"bounds": "{50, 25, 186, 36}",
 																						"text": "row 1  item 1",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -896,7 +954,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_76",
+																				"uiElementId": "RTA_164",
 																				"translation": "{660, 0}",
 																				"bounds": "{660, 0, 300, 150}",
 																				"index": "2"
@@ -908,7 +966,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_77",
+																						"uiElementId": "RTA_165",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -921,9 +979,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_78",
+																						"uiElementId": "RTA_166",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 198, 36}",
+																						"bounds": "{50, 25, 189, 36}",
 																						"text": "row 1  item 2",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -940,7 +998,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_79",
+																				"uiElementId": "RTA_167",
 																				"translation": "{990, 0}",
 																				"bounds": "{990, 0, 300, 150}",
 																				"index": "3"
@@ -952,7 +1010,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_80",
+																						"uiElementId": "RTA_168",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -965,9 +1023,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_81",
+																						"uiElementId": "RTA_169",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 3",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -984,7 +1042,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_82",
+																				"uiElementId": "RTA_170",
 																				"translation": "{1320, 0}",
 																				"bounds": "{1320, 0, 300, 150}",
 																				"index": "4"
@@ -996,7 +1054,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_83",
+																						"uiElementId": "RTA_171",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1009,9 +1067,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_84",
+																						"uiElementId": "RTA_172",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 4",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1028,7 +1086,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_85",
+																				"uiElementId": "RTA_173",
 																				"translation": "{1650, 0}",
 																				"bounds": "{1650, 0, 300, 150}",
 																				"index": "5"
@@ -1040,7 +1098,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_86",
+																						"uiElementId": "RTA_174",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1053,9 +1111,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_87",
+																						"uiElementId": "RTA_175",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 5",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1077,9 +1135,9 @@
 														"name": "rowListWithCustomTitleComponent",
 														"focusable": "true",
 														"rcid": "0",
-														"uiElementId": "RTA_26",
+														"uiElementId": "RTA_30",
 														"translation": "{150, 700}",
-														"bounds": "{128, 678, 1964, 444}",
+														"bounds": "{135, 685, 1950, 430}",
 														"children": "3",
 														"count": "2",
 														"focusItem": "0",
@@ -1105,7 +1163,7 @@
 																	"attributes": {
 																		"children": "1",
 																		"rcid": "0",
-																		"bounds": "{0, 0, 210, 36}",
+																		"bounds": "{0, 0, 201, 36}",
 																		"index": "0"
 																	},
 																	"children": [
@@ -1116,8 +1174,8 @@
 																				"children": "1",
 																				"extends": "Group",
 																				"rcid": "0",
-																				"uiElementId": "RTA_65",
-																				"bounds": "{0, 0, 210, 36}",
+																				"uiElementId": "RTA_153",
+																				"bounds": "{0, 0, 201, 36}",
 																				"index": "0"
 																			},
 																			"children": [
@@ -1127,8 +1185,8 @@
 																					"attributes": {
 																						"name": "label",
 																						"rcid": "0",
-																						"uiElementId": "RTA_66",
-																						"bounds": "{0, 0, 210, 36}",
+																						"uiElementId": "RTA_154",
+																						"bounds": "{0, 0, 201, 36}",
 																						"text": "custom:row 0",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1146,7 +1204,7 @@
 																		"rcid": "0",
 																		"visible": "false",
 																		"opacity": "0",
-																		"translation": "{1838, 0}",
+																		"translation": "{1842, 0}",
 																		"text": "1 of 1",
 																		"color": "#ffffffff",
 																		"index": "0"
@@ -1160,7 +1218,7 @@
 																		"focusable": "true",
 																		"rcid": "0",
 																		"translation": "{0, 36}",
-																		"bounds": "{-22, 14, 1964, 194}",
+																		"bounds": "{-15, 21, 1950, 180}",
 																		"children": "3",
 																		"count": "1",
 																		"focusItem": "0",
@@ -1175,7 +1233,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_67",
+																				"uiElementId": "RTA_155",
 																				"index": "0",
 																				"focused": "true",
 																				"bounds": "{0, 0, 300, 150}"
@@ -1187,7 +1245,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_68",
+																						"uiElementId": "RTA_156",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1200,9 +1258,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_69",
+																						"uiElementId": "RTA_157",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 205, 36}",
+																						"bounds": "{50, 25, 195, 36}",
 																						"text": "row 0  item 0",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1244,7 +1302,7 @@
 																	"attributes": {
 																		"children": "1",
 																		"rcid": "0",
-																		"bounds": "{0, 0, 205, 36}",
+																		"bounds": "{0, 0, 197, 36}",
 																		"index": "0"
 																	},
 																	"children": [
@@ -1255,8 +1313,8 @@
 																				"children": "1",
 																				"extends": "Group",
 																				"rcid": "0",
-																				"uiElementId": "RTA_88",
-																				"bounds": "{0, 0, 205, 36}",
+																				"uiElementId": "RTA_176",
+																				"bounds": "{0, 0, 197, 36}",
 																				"index": "0"
 																			},
 																			"children": [
@@ -1266,8 +1324,8 @@
 																					"attributes": {
 																						"name": "label",
 																						"rcid": "0",
-																						"uiElementId": "RTA_89",
-																						"bounds": "{0, 0, 205, 36}",
+																						"uiElementId": "RTA_177",
+																						"bounds": "{0, 0, 197, 36}",
 																						"text": "custom:row 1",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1298,8 +1356,8 @@
 																		"rcid": "0",
 																		"visible": "false",
 																		"translation": "{0, 36}",
-																		"children": "10",
-																		"count": "8",
+																		"children": "52",
+																		"count": "50",
 																		"focusItem": "0",
 																		"index": "0"
 																	},
@@ -1312,7 +1370,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_90",
+																				"uiElementId": "RTA_178",
 																				"bounds": "{0, 0, 300, 150}",
 																				"index": "0",
 																				"focused": "true"
@@ -1324,7 +1382,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_91",
+																						"uiElementId": "RTA_179",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1337,9 +1395,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_92",
+																						"uiElementId": "RTA_180",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 200, 36}",
+																						"bounds": "{50, 25, 191, 36}",
 																						"text": "row 1  item 0",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1356,7 +1414,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_93",
+																				"uiElementId": "RTA_181",
 																				"translation": "{330, 0}",
 																				"bounds": "{330, 0, 300, 150}",
 																				"index": "1"
@@ -1368,7 +1426,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_94",
+																						"uiElementId": "RTA_182",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1381,9 +1439,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_95",
+																						"uiElementId": "RTA_183",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 195, 36}",
+																						"bounds": "{50, 25, 186, 36}",
 																						"text": "row 1  item 1",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1400,7 +1458,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_96",
+																				"uiElementId": "RTA_184",
 																				"translation": "{660, 0}",
 																				"bounds": "{660, 0, 300, 150}",
 																				"index": "2"
@@ -1412,7 +1470,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_97",
+																						"uiElementId": "RTA_185",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1425,9 +1483,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_98",
+																						"uiElementId": "RTA_186",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 198, 36}",
+																						"bounds": "{50, 25, 189, 36}",
 																						"text": "row 1  item 2",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1444,7 +1502,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_99",
+																				"uiElementId": "RTA_187",
 																				"translation": "{990, 0}",
 																				"bounds": "{990, 0, 300, 150}",
 																				"index": "3"
@@ -1456,7 +1514,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_100",
+																						"uiElementId": "RTA_188",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1469,9 +1527,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_101",
+																						"uiElementId": "RTA_189",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 3",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1488,7 +1546,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_102",
+																				"uiElementId": "RTA_190",
 																				"translation": "{1320, 0}",
 																				"bounds": "{1320, 0, 300, 150}",
 																				"index": "4"
@@ -1500,7 +1558,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_103",
+																						"uiElementId": "RTA_191",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1513,9 +1571,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_104",
+																						"uiElementId": "RTA_192",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 4",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1532,7 +1590,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_105",
+																				"uiElementId": "RTA_193",
 																				"translation": "{1650, 0}",
 																				"bounds": "{1650, 0, 300, 150}",
 																				"index": "5"
@@ -1544,7 +1602,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_106",
+																						"uiElementId": "RTA_194",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1557,9 +1615,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_107",
+																						"uiElementId": "RTA_195",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 5",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1589,7 +1647,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_90",
+																				"uiElementId": "RTA_178",
 																				"bounds": "{0, 0, 300, 150}",
 																				"index": "0"
 																			},
@@ -1600,7 +1658,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_91",
+																						"uiElementId": "RTA_179",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1613,9 +1671,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_92",
+																						"uiElementId": "RTA_180",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 200, 36}",
+																						"bounds": "{50, 25, 191, 36}",
 																						"text": "row 1  item 0",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1632,7 +1690,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_93",
+																				"uiElementId": "RTA_181",
 																				"translation": "{330, 0}",
 																				"bounds": "{330, 0, 300, 150}",
 																				"index": "1"
@@ -1644,7 +1702,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_94",
+																						"uiElementId": "RTA_182",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1657,9 +1715,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_95",
+																						"uiElementId": "RTA_183",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 195, 36}",
+																						"bounds": "{50, 25, 186, 36}",
 																						"text": "row 1  item 1",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1676,7 +1734,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_96",
+																				"uiElementId": "RTA_184",
 																				"translation": "{660, 0}",
 																				"bounds": "{660, 0, 300, 150}",
 																				"index": "2"
@@ -1688,7 +1746,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_97",
+																						"uiElementId": "RTA_185",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1701,9 +1759,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_98",
+																						"uiElementId": "RTA_186",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 198, 36}",
+																						"bounds": "{50, 25, 189, 36}",
 																						"text": "row 1  item 2",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1720,7 +1778,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_99",
+																				"uiElementId": "RTA_187",
 																				"translation": "{990, 0}",
 																				"bounds": "{990, 0, 300, 150}",
 																				"index": "3"
@@ -1732,7 +1790,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_100",
+																						"uiElementId": "RTA_188",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1745,9 +1803,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_101",
+																						"uiElementId": "RTA_189",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 3",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1764,7 +1822,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_102",
+																				"uiElementId": "RTA_190",
 																				"translation": "{1320, 0}",
 																				"bounds": "{1320, 0, 300, 150}",
 																				"index": "4"
@@ -1776,7 +1834,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_103",
+																						"uiElementId": "RTA_191",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1789,9 +1847,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_104",
+																						"uiElementId": "RTA_192",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 4",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1808,7 +1866,7 @@
 																				"extends": "Group",
 																				"focusable": "true",
 																				"rcid": "0",
-																				"uiElementId": "RTA_105",
+																				"uiElementId": "RTA_193",
 																				"translation": "{1650, 0}",
 																				"bounds": "{1650, 0, 300, 150}",
 																				"index": "5"
@@ -1820,7 +1878,7 @@
 																					"attributes": {
 																						"name": "rect",
 																						"rcid": "0",
-																						"uiElementId": "RTA_106",
+																						"uiElementId": "RTA_194",
 																						"bounds": "{0, 0, 300, 150}",
 																						"color": "#ff0000ff",
 																						"index": "0"
@@ -1833,9 +1891,9 @@
 																					"attributes": {
 																						"name": "title",
 																						"rcid": "0",
-																						"uiElementId": "RTA_107",
+																						"uiElementId": "RTA_195",
 																						"translation": "{50, 25}",
-																						"bounds": "{50, 25, 197, 36}",
+																						"bounds": "{50, 25, 188, 36}",
 																						"text": "row 1  item 5",
 																						"color": "#fefefeff",
 																						"index": "0"
@@ -1857,9 +1915,9 @@
 														"name": "markupGrid",
 														"focusable": "true",
 														"rcid": "0",
-														"uiElementId": "RTA_27",
+														"uiElementId": "RTA_31",
 														"translation": "{500, 100}",
-														"bounds": "{478, 78, 704, 428}",
+														"bounds": "{485, 85, 690, 414}",
 														"children": "10",
 														"count": "8",
 														"focusItem": "0",
@@ -1874,7 +1932,7 @@
 																"extends": "Group",
 																"focusable": "true",
 																"rcid": "0",
-																"uiElementId": "RTA_108",
+																"uiElementId": "RTA_196",
 																"index": "0",
 																"focused": "true",
 																"bounds": "{0, 0, 150, 150}"
@@ -1886,7 +1944,7 @@
 																	"attributes": {
 																		"name": "rect",
 																		"rcid": "0",
-																		"uiElementId": "RTA_109",
+																		"uiElementId": "RTA_197",
 																		"bounds": "{0, 0, 150, 150}",
 																		"color": "#0000bbff",
 																		"index": "0"
@@ -1903,7 +1961,7 @@
 																"extends": "Group",
 																"focusable": "true",
 																"rcid": "0",
-																"uiElementId": "RTA_110",
+																"uiElementId": "RTA_198",
 																"index": "1",
 																"bounds": "{165, 0, 150, 150}"
 															},
@@ -1914,7 +1972,7 @@
 																	"attributes": {
 																		"name": "rect",
 																		"rcid": "0",
-																		"uiElementId": "RTA_111",
+																		"uiElementId": "RTA_199",
 																		"bounds": "{0, 0, 150, 150}",
 																		"color": "#0000bbff",
 																		"index": "0"
@@ -1931,7 +1989,7 @@
 																"extends": "Group",
 																"focusable": "true",
 																"rcid": "0",
-																"uiElementId": "RTA_112",
+																"uiElementId": "RTA_200",
 																"index": "2",
 																"bounds": "{330, 0, 150, 150}"
 															},
@@ -1942,7 +2000,7 @@
 																	"attributes": {
 																		"name": "rect",
 																		"rcid": "0",
-																		"uiElementId": "RTA_113",
+																		"uiElementId": "RTA_201",
 																		"bounds": "{0, 0, 150, 150}",
 																		"color": "#0000bbff",
 																		"index": "0"
@@ -1959,7 +2017,7 @@
 																"extends": "Group",
 																"focusable": "true",
 																"rcid": "0",
-																"uiElementId": "RTA_114",
+																"uiElementId": "RTA_202",
 																"index": "3",
 																"bounds": "{495, 0, 150, 150}"
 															},
@@ -1970,7 +2028,7 @@
 																	"attributes": {
 																		"name": "rect",
 																		"rcid": "0",
-																		"uiElementId": "RTA_115",
+																		"uiElementId": "RTA_203",
 																		"bounds": "{0, 0, 150, 150}",
 																		"color": "#0000bbff",
 																		"index": "0"
@@ -1987,7 +2045,7 @@
 																"extends": "Group",
 																"focusable": "true",
 																"rcid": "0",
-																"uiElementId": "RTA_116",
+																"uiElementId": "RTA_204",
 																"index": "4",
 																"bounds": "{0, 165, 150, 150}"
 															},
@@ -1998,7 +2056,7 @@
 																	"attributes": {
 																		"name": "rect",
 																		"rcid": "0",
-																		"uiElementId": "RTA_117",
+																		"uiElementId": "RTA_205",
 																		"bounds": "{0, 0, 150, 150}",
 																		"color": "#0000bbff",
 																		"index": "0"
@@ -2015,7 +2073,7 @@
 																"extends": "Group",
 																"focusable": "true",
 																"rcid": "0",
-																"uiElementId": "RTA_118",
+																"uiElementId": "RTA_206",
 																"index": "5",
 																"bounds": "{165, 165, 150, 150}"
 															},
@@ -2026,7 +2084,7 @@
 																	"attributes": {
 																		"name": "rect",
 																		"rcid": "0",
-																		"uiElementId": "RTA_119",
+																		"uiElementId": "RTA_207",
 																		"bounds": "{0, 0, 150, 150}",
 																		"color": "#0000bbff",
 																		"index": "0"
@@ -2043,7 +2101,7 @@
 																"extends": "Group",
 																"focusable": "true",
 																"rcid": "0",
-																"uiElementId": "RTA_120",
+																"uiElementId": "RTA_208",
 																"index": "6",
 																"bounds": "{330, 165, 150, 150}"
 															},
@@ -2054,7 +2112,7 @@
 																	"attributes": {
 																		"name": "rect",
 																		"rcid": "0",
-																		"uiElementId": "RTA_121",
+																		"uiElementId": "RTA_209",
 																		"bounds": "{0, 0, 150, 150}",
 																		"color": "#0000bbff",
 																		"index": "0"
@@ -2071,7 +2129,7 @@
 																"extends": "Group",
 																"focusable": "true",
 																"rcid": "0",
-																"uiElementId": "RTA_122",
+																"uiElementId": "RTA_210",
 																"index": "7",
 																"bounds": "{495, 165, 150, 150}"
 															},
@@ -2082,7 +2140,7 @@
 																	"attributes": {
 																		"name": "rect",
 																		"rcid": "0",
-																		"uiElementId": "RTA_123",
+																		"uiElementId": "RTA_211",
 																		"bounds": "{0, 0, 150, 150}",
 																		"color": "#0000bbff",
 																		"index": "0"

--- a/client/src/test/mocks/ECP/getAppUI/appUIResponse.json
+++ b/client/src/test/mocks/ECP/getAppUI/appUIResponse.json
@@ -1,0 +1,2107 @@
+{
+	"name": "app-ui",
+	"value": "",
+	"attributes": {},
+	"children": [
+		{
+			"name": "status",
+			"value": "OK",
+			"attributes": {},
+			"children": []
+		},
+		{
+			"name": "topscreen",
+			"value": "",
+			"attributes": {},
+			"children": [
+				{
+					"name": "plugin",
+					"value": "",
+					"attributes": {
+						"id": "dev",
+						"name": "TestChannel"
+					},
+					"children": []
+				},
+				{
+					"name": "screen",
+					"value": "",
+					"attributes": {
+						"type": "SGScreen",
+						"focused": "true"
+					},
+					"children": [
+						{
+							"name": "MainScene",
+							"value": "",
+							"attributes": {
+								"children": "0",
+								"extends": "Scene",
+								"focused": "true",
+								"focusable": "true",
+								"rcid": "0",
+								"uiElementId": "RTA_1",
+								"bounds": "{0, 0, 2192, 1222}"
+							},
+							"children": [
+								{
+									"name": "Poster",
+									"value": "",
+									"attributes": {
+										"rcid": "0",
+										"inheritParentTransform": "false",
+										"inheritParentOpacity": "false",
+										"bounds": "{0, 0, 1920, 1080}",
+										"uri": "/RokuOS/Artwork/SceneGraph/GenevaTheme/Base/FHD/background.png",
+										"loadStatus": "3",
+										"index": "0"
+									},
+									"children": []
+								},
+								{
+									"name": "Poster",
+									"value": "",
+									"attributes": {
+										"name": "poster",
+										"rcid": "0",
+										"uiElementId": "RTA_2",
+										"translation": "{10, 20}",
+										"index": "1"
+									},
+									"children": []
+								},
+								{
+									"name": "Rectangle",
+									"value": "",
+									"attributes": {
+										"name": "invisibleRect",
+										"rcid": "0",
+										"uiElementId": "RTA_3",
+										"visible": "false",
+										"color": "#ff0000ff",
+										"index": "0"
+									},
+									"children": []
+								},
+								{
+									"name": "RenderableNode",
+									"value": "",
+									"attributes": {
+										"name": "temporaryNodesGroup",
+										"rcid": "0",
+										"uiElementId": "RTA_5",
+										"index": "0"
+									},
+									"children": []
+								},
+								{
+									"name": "RenderableNode",
+									"value": "",
+									"attributes": {
+										"children": "1",
+										"name": "pagesContainerGroup",
+										"focused": "true",
+										"rcid": "0",
+										"uiElementId": "RTA_6",
+										"bounds": "{100, 100, 2092, 1122}",
+										"index": "1"
+									},
+									"children": [
+										{
+											"name": "LandingPage",
+											"value": "",
+											"attributes": {
+												"children": "9",
+												"extends": "BasePage",
+												"focused": "true",
+												"rcid": "0",
+												"uiElementId": "RTA_11",
+												"translation": "{100, 100}",
+												"bounds": "{100, 100, 2092, 1122}",
+												"index": "0"
+											},
+											"children": [
+												{
+													"name": "Rectangle",
+													"value": "",
+													"attributes": {
+														"rcid": "0",
+														"uiElementId": "RTA_12",
+														"bounds": "{0, 0, 1920, 1080}",
+														"color": "#000000ff",
+														"index": "0"
+													},
+													"children": []
+												},
+												{
+													"name": "Rectangle",
+													"value": "",
+													"attributes": {
+														"name": "rect",
+														"rcid": "0",
+														"uiElementId": "RTA_13",
+														"bounds": "{0, 0, 1920, 1080}",
+														"color": "#111111ff",
+														"index": "1"
+													},
+													"children": []
+												},
+												{
+													"name": "Rectangle",
+													"value": "",
+													"attributes": {
+														"children": "1",
+														"name": "rect2",
+														"rcid": "0",
+														"uiElementId": "RTA_14",
+														"translation": "{100, 100}",
+														"bounds": "{100, 100, 100, 100}",
+														"color": "#00ff00ff",
+														"index": "2"
+													},
+													"children": [
+														{
+															"name": "Rectangle",
+															"value": "",
+															"attributes": {
+																"name": "rect3",
+																"rcid": "0",
+																"uiElementId": "RTA_15",
+																"translation": "{25, 25}",
+																"bounds": "{25, 25, 50, 50}",
+																"color": "#0000ffff",
+																"index": "0"
+															},
+															"children": []
+														}
+													]
+												},
+												{
+													"name": "AppButton",
+													"value": "",
+													"attributes": {
+														"children": "5",
+														"extends": "Button",
+														"name": "loginButton",
+														"focused": "true",
+														"focusable": "true",
+														"rcid": "0",
+														"uiElementId": "RTA_16",
+														"translation": "{300, 150}",
+														"bounds": "{300, 150, 163, 96}",
+														"index": "0"
+													},
+													"children": [
+														{
+															"name": "Poster",
+															"value": "",
+															"attributes": {
+																"rcid": "0",
+																"bounds": "{0, 0, 163, 96}",
+																"uri": "/RokuOS/Artwork/SceneGraph/GenevaTheme/Base/FHD/focus_list.9.png",
+																"loadStatus": "3",
+																"index": "0"
+															},
+															"children": []
+														},
+														{
+															"name": "Poster",
+															"value": "",
+															"attributes": {
+																"rcid": "0",
+																"visible": "false",
+																"uri": "/RokuOS/Artwork/SceneGraph/GenevaTheme/Base/FHD/focus_footprint.9.png",
+																"loadStatus": "3",
+																"index": "1"
+															},
+															"children": []
+														},
+														{
+															"name": "Label",
+															"value": "",
+															"attributes": {
+																"rcid": "0",
+																"translation": "{36, 29}",
+																"bounds": "{36, 29, 91, 38}",
+																"text": "Login",
+																"color": "#121212ff",
+																"index": "0"
+															},
+															"children": []
+														},
+														{
+															"name": "Poster",
+															"value": "",
+															"attributes": {
+																"rcid": "0",
+																"visible": "false",
+																"translation": "{36, 48}",
+																"loadStatus": "2",
+																"index": "2"
+															},
+															"children": []
+														},
+														{
+															"name": "Poster",
+															"value": "",
+															"attributes": {
+																"rcid": "0",
+																"translation": "{36, 48}",
+																"loadStatus": "2",
+																"index": "3"
+															},
+															"children": []
+														}
+													]
+												},
+												{
+													"name": "RenderableNode",
+													"value": "",
+													"attributes": {
+														"children": "3",
+														"name": "testTarget",
+														"rcid": "0",
+														"uiElementId": "RTA_17",
+														"index": "0"
+													},
+													"children": [
+														{
+															"name": "RenderableNode",
+															"value": "",
+															"attributes": {
+																"name": "child1",
+																"rcid": "0",
+																"uiElementId": "RTA_18",
+																"index": "0"
+															},
+															"children": []
+														},
+														{
+															"name": "RenderableNode",
+															"value": "",
+															"attributes": {
+																"children": "3",
+																"name": "child2",
+																"rcid": "0",
+																"uiElementId": "RTA_19",
+																"index": "1"
+															},
+															"children": [
+																{
+																	"name": "RenderableNode",
+																	"value": "",
+																	"attributes": {
+																		"name": "subchild1",
+																		"rcid": "0",
+																		"uiElementId": "RTA_20",
+																		"index": "0"
+																	},
+																	"children": []
+																},
+																{
+																	"name": "RenderableNode",
+																	"value": "",
+																	"attributes": {
+																		"name": "subchild2",
+																		"rcid": "0",
+																		"uiElementId": "RTA_21",
+																		"index": "1"
+																	},
+																	"children": []
+																},
+																{
+																	"name": "RenderableNode",
+																	"value": "",
+																	"attributes": {
+																		"name": "subchild3",
+																		"rcid": "0",
+																		"uiElementId": "RTA_22",
+																		"index": "2"
+																	},
+																	"children": []
+																}
+															]
+														},
+														{
+															"name": "RenderableNode",
+															"value": "",
+															"attributes": {
+																"name": "child3",
+																"rcid": "0",
+																"uiElementId": "RTA_23",
+																"index": "2"
+															},
+															"children": []
+														}
+													]
+												},
+												{
+													"name": "Poster",
+													"value": "",
+													"attributes": {
+														"name": "poster",
+														"rcid": "0",
+														"uiElementId": "RTA_24",
+														"index": "0"
+													},
+													"children": []
+												},
+												{
+													"name": "RowList",
+													"value": "",
+													"attributes": {
+														"name": "rowListWithoutCustomTitleComponent",
+														"focusable": "true",
+														"rcid": "0",
+														"uiElementId": "RTA_25",
+														"translation": "{150, 300}",
+														"bounds": "{128, 278, 1964, 444}",
+														"children": "3",
+														"count": "2",
+														"focusItem": "0",
+														"index": "0"
+													},
+													"children": [
+														{
+															"name": "RowListItem",
+															"value": "",
+															"attributes": {
+																"children": "4",
+																"name": "Row",
+																"focusable": "true",
+																"rcid": "0",
+																"index": "0",
+																"focused": "true",
+																"bounds": "{0, 36, 1920, 150}"
+															},
+															"children": [
+																{
+																	"name": "Label",
+																	"value": "",
+																	"attributes": {
+																		"rcid": "0",
+																		"bounds": "{0, 0, 87, 36}",
+																		"text": "row 0",
+																		"color": "#ffffffff",
+																		"index": "0"
+																	},
+																	"children": []
+																},
+																{
+																	"name": "Label",
+																	"value": "",
+																	"attributes": {
+																		"rcid": "0",
+																		"visible": "false",
+																		"opacity": "0",
+																		"translation": "{1838, 0}",
+																		"text": "1 of 1",
+																		"color": "#ffffffff",
+																		"index": "1"
+																	},
+																	"children": []
+																},
+																{
+																	"name": "MarkupGrid",
+																	"value": "",
+																	"attributes": {
+																		"focusable": "true",
+																		"rcid": "0",
+																		"translation": "{0, 36}",
+																		"bounds": "{-22, 14, 1964, 194}",
+																		"children": "3",
+																		"count": "1",
+																		"focusItem": "0",
+																		"index": "0"
+																	},
+																	"children": [
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_62",
+																				"index": "0",
+																				"focused": "true",
+																				"bounds": "{0, 0, 300, 150}"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_63",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_64",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 205, 36}",
+																						"text": "row 0  item 0",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		}
+																	]
+																},
+																{
+																	"name": "RenderableNode",
+																	"value": "",
+																	"attributes": {
+																		"rcid": "0",
+																		"visible": "false",
+																		"translation": "{0, 36}",
+																		"index": "0"
+																	},
+																	"children": []
+																}
+															]
+														},
+														{
+															"name": "RowListItem",
+															"value": "",
+															"attributes": {
+																"children": "4",
+																"name": "Row",
+																"focusable": "true",
+																"rcid": "0",
+																"index": "1",
+																"bounds": "{0, 236, 1920, 150}"
+															},
+															"children": [
+																{
+																	"name": "Label",
+																	"value": "",
+																	"attributes": {
+																		"rcid": "0",
+																		"bounds": "{0, 0, 82, 36}",
+																		"text": "row 1",
+																		"color": "#ffffffff",
+																		"index": "0"
+																	},
+																	"children": []
+																},
+																{
+																	"name": "Label",
+																	"value": "",
+																	"attributes": {
+																		"rcid": "0",
+																		"opacity": "0",
+																		"text": "",
+																		"color": "#ffffffff",
+																		"index": "1"
+																	},
+																	"children": []
+																},
+																{
+																	"name": "MarkupGrid",
+																	"value": "",
+																	"attributes": {
+																		"focusable": "true",
+																		"rcid": "0",
+																		"visible": "false",
+																		"translation": "{0, 36}",
+																		"children": "10",
+																		"count": "8",
+																		"focusItem": "0",
+																		"index": "0"
+																	},
+																	"children": [
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_70",
+																				"bounds": "{0, 0, 300, 150}",
+																				"index": "0",
+																				"focused": "true"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_71",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_72",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 200, 36}",
+																						"text": "row 1  item 0",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_73",
+																				"translation": "{330, 0}",
+																				"bounds": "{330, 0, 300, 150}",
+																				"index": "1"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_74",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_75",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 195, 36}",
+																						"text": "row 1  item 1",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_76",
+																				"translation": "{660, 0}",
+																				"bounds": "{660, 0, 300, 150}",
+																				"index": "2"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_77",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_78",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 198, 36}",
+																						"text": "row 1  item 2",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_79",
+																				"translation": "{990, 0}",
+																				"bounds": "{990, 0, 300, 150}",
+																				"index": "3"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_80",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_81",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 3",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_82",
+																				"translation": "{1320, 0}",
+																				"bounds": "{1320, 0, 300, 150}",
+																				"index": "4"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_83",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_84",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 4",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_85",
+																				"translation": "{1650, 0}",
+																				"bounds": "{1650, 0, 300, 150}",
+																				"index": "5"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_86",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_87",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 5",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		}
+																	]
+																},
+																{
+																	"name": "RenderableNode",
+																	"value": "",
+																	"attributes": {
+																		"children": "6",
+																		"rcid": "0",
+																		"translation": "{0, 36}",
+																		"bounds": "{0, 36, 1950, 150}",
+																		"index": "0"
+																	},
+																	"children": [
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_70",
+																				"bounds": "{0, 0, 300, 150}",
+																				"index": "0"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_71",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_72",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 200, 36}",
+																						"text": "row 1  item 0",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_73",
+																				"translation": "{330, 0}",
+																				"bounds": "{330, 0, 300, 150}",
+																				"index": "1"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_74",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_75",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 195, 36}",
+																						"text": "row 1  item 1",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_76",
+																				"translation": "{660, 0}",
+																				"bounds": "{660, 0, 300, 150}",
+																				"index": "2"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_77",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_78",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 198, 36}",
+																						"text": "row 1  item 2",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_79",
+																				"translation": "{990, 0}",
+																				"bounds": "{990, 0, 300, 150}",
+																				"index": "3"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_80",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_81",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 3",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_82",
+																				"translation": "{1320, 0}",
+																				"bounds": "{1320, 0, 300, 150}",
+																				"index": "4"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_83",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_84",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 4",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_85",
+																				"translation": "{1650, 0}",
+																				"bounds": "{1650, 0, 300, 150}",
+																				"index": "5"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_86",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_87",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 5",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"name": "RowList",
+													"value": "",
+													"attributes": {
+														"name": "rowListWithCustomTitleComponent",
+														"focusable": "true",
+														"rcid": "0",
+														"uiElementId": "RTA_26",
+														"translation": "{150, 700}",
+														"bounds": "{128, 678, 1964, 444}",
+														"children": "3",
+														"count": "2",
+														"focusItem": "0",
+														"index": "1"
+													},
+													"children": [
+														{
+															"name": "RowListItem",
+															"value": "",
+															"attributes": {
+																"children": "4",
+																"name": "Row",
+																"focusable": "true",
+																"rcid": "0",
+																"index": "0",
+																"focused": "true",
+																"bounds": "{0, 36, 1920, 150}"
+															},
+															"children": [
+																{
+																	"name": "RenderableNode",
+																	"value": "",
+																	"attributes": {
+																		"children": "1",
+																		"rcid": "0",
+																		"bounds": "{0, 0, 210, 36}",
+																		"index": "0"
+																	},
+																	"children": [
+																		{
+																			"name": "RowListRowTitleComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "1",
+																				"extends": "Group",
+																				"rcid": "0",
+																				"uiElementId": "RTA_65",
+																				"bounds": "{0, 0, 210, 36}",
+																				"index": "0"
+																			},
+																			"children": [
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "label",
+																						"rcid": "0",
+																						"uiElementId": "RTA_66",
+																						"bounds": "{0, 0, 210, 36}",
+																						"text": "custom:row 0",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		}
+																	]
+																},
+																{
+																	"name": "Label",
+																	"value": "",
+																	"attributes": {
+																		"rcid": "0",
+																		"visible": "false",
+																		"opacity": "0",
+																		"translation": "{1838, 0}",
+																		"text": "1 of 1",
+																		"color": "#ffffffff",
+																		"index": "0"
+																	},
+																	"children": []
+																},
+																{
+																	"name": "MarkupGrid",
+																	"value": "",
+																	"attributes": {
+																		"focusable": "true",
+																		"rcid": "0",
+																		"translation": "{0, 36}",
+																		"bounds": "{-22, 14, 1964, 194}",
+																		"children": "3",
+																		"count": "1",
+																		"focusItem": "0",
+																		"index": "0"
+																	},
+																	"children": [
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_67",
+																				"index": "0",
+																				"focused": "true",
+																				"bounds": "{0, 0, 300, 150}"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_68",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_69",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 205, 36}",
+																						"text": "row 0  item 0",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		}
+																	]
+																},
+																{
+																	"name": "RenderableNode",
+																	"value": "",
+																	"attributes": {
+																		"rcid": "0",
+																		"visible": "false",
+																		"translation": "{0, 36}",
+																		"index": "1"
+																	},
+																	"children": []
+																}
+															]
+														},
+														{
+															"name": "RowListItem",
+															"value": "",
+															"attributes": {
+																"children": "4",
+																"name": "Row",
+																"focusable": "true",
+																"rcid": "0",
+																"index": "1",
+																"bounds": "{0, 236, 1920, 150}"
+															},
+															"children": [
+																{
+																	"name": "RenderableNode",
+																	"value": "",
+																	"attributes": {
+																		"children": "1",
+																		"rcid": "0",
+																		"bounds": "{0, 0, 205, 36}",
+																		"index": "0"
+																	},
+																	"children": [
+																		{
+																			"name": "RowListRowTitleComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "1",
+																				"extends": "Group",
+																				"rcid": "0",
+																				"uiElementId": "RTA_88",
+																				"bounds": "{0, 0, 205, 36}",
+																				"index": "0"
+																			},
+																			"children": [
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "label",
+																						"rcid": "0",
+																						"uiElementId": "RTA_89",
+																						"bounds": "{0, 0, 205, 36}",
+																						"text": "custom:row 1",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		}
+																	]
+																},
+																{
+																	"name": "Label",
+																	"value": "",
+																	"attributes": {
+																		"rcid": "0",
+																		"opacity": "0",
+																		"text": "",
+																		"color": "#ffffffff",
+																		"index": "0"
+																	},
+																	"children": []
+																},
+																{
+																	"name": "MarkupGrid",
+																	"value": "",
+																	"attributes": {
+																		"focusable": "true",
+																		"rcid": "0",
+																		"visible": "false",
+																		"translation": "{0, 36}",
+																		"children": "10",
+																		"count": "8",
+																		"focusItem": "0",
+																		"index": "0"
+																	},
+																	"children": [
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_90",
+																				"bounds": "{0, 0, 300, 150}",
+																				"index": "0",
+																				"focused": "true"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_91",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_92",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 200, 36}",
+																						"text": "row 1  item 0",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_93",
+																				"translation": "{330, 0}",
+																				"bounds": "{330, 0, 300, 150}",
+																				"index": "1"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_94",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_95",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 195, 36}",
+																						"text": "row 1  item 1",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_96",
+																				"translation": "{660, 0}",
+																				"bounds": "{660, 0, 300, 150}",
+																				"index": "2"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_97",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_98",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 198, 36}",
+																						"text": "row 1  item 2",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_99",
+																				"translation": "{990, 0}",
+																				"bounds": "{990, 0, 300, 150}",
+																				"index": "3"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_100",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_101",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 3",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_102",
+																				"translation": "{1320, 0}",
+																				"bounds": "{1320, 0, 300, 150}",
+																				"index": "4"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_103",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_104",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 4",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_105",
+																				"translation": "{1650, 0}",
+																				"bounds": "{1650, 0, 300, 150}",
+																				"index": "5"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_106",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_107",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 5",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		}
+																	]
+																},
+																{
+																	"name": "RenderableNode",
+																	"value": "",
+																	"attributes": {
+																		"children": "6",
+																		"rcid": "0",
+																		"translation": "{0, 36}",
+																		"bounds": "{0, 36, 1950, 150}",
+																		"index": "1"
+																	},
+																	"children": [
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_90",
+																				"bounds": "{0, 0, 300, 150}",
+																				"index": "0"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_91",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_92",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 200, 36}",
+																						"text": "row 1  item 0",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_93",
+																				"translation": "{330, 0}",
+																				"bounds": "{330, 0, 300, 150}",
+																				"index": "1"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_94",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_95",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 195, 36}",
+																						"text": "row 1  item 1",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_96",
+																				"translation": "{660, 0}",
+																				"bounds": "{660, 0, 300, 150}",
+																				"index": "2"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_97",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_98",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 198, 36}",
+																						"text": "row 1  item 2",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_99",
+																				"translation": "{990, 0}",
+																				"bounds": "{990, 0, 300, 150}",
+																				"index": "3"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_100",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_101",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 3",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_102",
+																				"translation": "{1320, 0}",
+																				"bounds": "{1320, 0, 300, 150}",
+																				"index": "4"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_103",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_104",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 4",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		},
+																		{
+																			"name": "RowListItemComponent",
+																			"value": "",
+																			"attributes": {
+																				"children": "2",
+																				"extends": "Group",
+																				"focusable": "true",
+																				"rcid": "0",
+																				"uiElementId": "RTA_105",
+																				"translation": "{1650, 0}",
+																				"bounds": "{1650, 0, 300, 150}",
+																				"index": "5"
+																			},
+																			"children": [
+																				{
+																					"name": "Rectangle",
+																					"value": "",
+																					"attributes": {
+																						"name": "rect",
+																						"rcid": "0",
+																						"uiElementId": "RTA_106",
+																						"bounds": "{0, 0, 300, 150}",
+																						"color": "#ff0000ff",
+																						"index": "0"
+																					},
+																					"children": []
+																				},
+																				{
+																					"name": "Label",
+																					"value": "",
+																					"attributes": {
+																						"name": "title",
+																						"rcid": "0",
+																						"uiElementId": "RTA_107",
+																						"translation": "{50, 25}",
+																						"bounds": "{50, 25, 197, 36}",
+																						"text": "row 1  item 5",
+																						"color": "#fefefeff",
+																						"index": "0"
+																					},
+																					"children": []
+																				}
+																			]
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"name": "MarkupGrid",
+													"value": "",
+													"attributes": {
+														"name": "markupGrid",
+														"focusable": "true",
+														"rcid": "0",
+														"uiElementId": "RTA_27",
+														"translation": "{500, 100}",
+														"bounds": "{478, 78, 704, 428}",
+														"children": "10",
+														"count": "8",
+														"focusItem": "0",
+														"index": "0"
+													},
+													"children": [
+														{
+															"name": "MarkupGridItemComponent",
+															"value": "",
+															"attributes": {
+																"children": "1",
+																"extends": "Group",
+																"focusable": "true",
+																"rcid": "0",
+																"uiElementId": "RTA_108",
+																"index": "0",
+																"focused": "true",
+																"bounds": "{0, 0, 150, 150}"
+															},
+															"children": [
+																{
+																	"name": "Rectangle",
+																	"value": "",
+																	"attributes": {
+																		"name": "rect",
+																		"rcid": "0",
+																		"uiElementId": "RTA_109",
+																		"bounds": "{0, 0, 150, 150}",
+																		"color": "#0000bbff",
+																		"index": "0"
+																	},
+																	"children": []
+																}
+															]
+														},
+														{
+															"name": "MarkupGridItemComponent",
+															"value": "",
+															"attributes": {
+																"children": "1",
+																"extends": "Group",
+																"focusable": "true",
+																"rcid": "0",
+																"uiElementId": "RTA_110",
+																"index": "1",
+																"bounds": "{165, 0, 150, 150}"
+															},
+															"children": [
+																{
+																	"name": "Rectangle",
+																	"value": "",
+																	"attributes": {
+																		"name": "rect",
+																		"rcid": "0",
+																		"uiElementId": "RTA_111",
+																		"bounds": "{0, 0, 150, 150}",
+																		"color": "#0000bbff",
+																		"index": "0"
+																	},
+																	"children": []
+																}
+															]
+														},
+														{
+															"name": "MarkupGridItemComponent",
+															"value": "",
+															"attributes": {
+																"children": "1",
+																"extends": "Group",
+																"focusable": "true",
+																"rcid": "0",
+																"uiElementId": "RTA_112",
+																"index": "2",
+																"bounds": "{330, 0, 150, 150}"
+															},
+															"children": [
+																{
+																	"name": "Rectangle",
+																	"value": "",
+																	"attributes": {
+																		"name": "rect",
+																		"rcid": "0",
+																		"uiElementId": "RTA_113",
+																		"bounds": "{0, 0, 150, 150}",
+																		"color": "#0000bbff",
+																		"index": "0"
+																	},
+																	"children": []
+																}
+															]
+														},
+														{
+															"name": "MarkupGridItemComponent",
+															"value": "",
+															"attributes": {
+																"children": "1",
+																"extends": "Group",
+																"focusable": "true",
+																"rcid": "0",
+																"uiElementId": "RTA_114",
+																"index": "3",
+																"bounds": "{495, 0, 150, 150}"
+															},
+															"children": [
+																{
+																	"name": "Rectangle",
+																	"value": "",
+																	"attributes": {
+																		"name": "rect",
+																		"rcid": "0",
+																		"uiElementId": "RTA_115",
+																		"bounds": "{0, 0, 150, 150}",
+																		"color": "#0000bbff",
+																		"index": "0"
+																	},
+																	"children": []
+																}
+															]
+														},
+														{
+															"name": "MarkupGridItemComponent",
+															"value": "",
+															"attributes": {
+																"children": "1",
+																"extends": "Group",
+																"focusable": "true",
+																"rcid": "0",
+																"uiElementId": "RTA_116",
+																"index": "4",
+																"bounds": "{0, 165, 150, 150}"
+															},
+															"children": [
+																{
+																	"name": "Rectangle",
+																	"value": "",
+																	"attributes": {
+																		"name": "rect",
+																		"rcid": "0",
+																		"uiElementId": "RTA_117",
+																		"bounds": "{0, 0, 150, 150}",
+																		"color": "#0000bbff",
+																		"index": "0"
+																	},
+																	"children": []
+																}
+															]
+														},
+														{
+															"name": "MarkupGridItemComponent",
+															"value": "",
+															"attributes": {
+																"children": "1",
+																"extends": "Group",
+																"focusable": "true",
+																"rcid": "0",
+																"uiElementId": "RTA_118",
+																"index": "5",
+																"bounds": "{165, 165, 150, 150}"
+															},
+															"children": [
+																{
+																	"name": "Rectangle",
+																	"value": "",
+																	"attributes": {
+																		"name": "rect",
+																		"rcid": "0",
+																		"uiElementId": "RTA_119",
+																		"bounds": "{0, 0, 150, 150}",
+																		"color": "#0000bbff",
+																		"index": "0"
+																	},
+																	"children": []
+																}
+															]
+														},
+														{
+															"name": "MarkupGridItemComponent",
+															"value": "",
+															"attributes": {
+																"children": "1",
+																"extends": "Group",
+																"focusable": "true",
+																"rcid": "0",
+																"uiElementId": "RTA_120",
+																"index": "6",
+																"bounds": "{330, 165, 150, 150}"
+															},
+															"children": [
+																{
+																	"name": "Rectangle",
+																	"value": "",
+																	"attributes": {
+																		"name": "rect",
+																		"rcid": "0",
+																		"uiElementId": "RTA_121",
+																		"bounds": "{0, 0, 150, 150}",
+																		"color": "#0000bbff",
+																		"index": "0"
+																	},
+																	"children": []
+																}
+															]
+														},
+														{
+															"name": "MarkupGridItemComponent",
+															"value": "",
+															"attributes": {
+																"children": "1",
+																"extends": "Group",
+																"focusable": "true",
+																"rcid": "0",
+																"uiElementId": "RTA_122",
+																"index": "7",
+																"bounds": "{495, 165, 150, 150}"
+															},
+															"children": [
+																{
+																	"name": "Rectangle",
+																	"value": "",
+																	"attributes": {
+																		"name": "rect",
+																		"rcid": "0",
+																		"uiElementId": "RTA_123",
+																		"bounds": "{0, 0, 150, 150}",
+																		"color": "#0000bbff",
+																		"index": "0"
+																	},
+																	"children": []
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/client/src/test/utils.ts
+++ b/client/src/test/utils.ts
@@ -7,8 +7,17 @@ export async function getMock(mockFilePath: string) {
 	return await fsExtra.readFile(mockFilePath, 'utf8');
 }
 
-export async function getTestMock(contextOrSuite: Mocha.Context | Mocha.Suite, extension: MockFileFormat = 'json'): Promise<object | string> {
-	const mockFilePath = 'src/test/mocks/' + utils.generateFileNameForTest(contextOrSuite, extension);
+export async function getTestMock(contextOrSuiteOrString: Mocha.Context | Mocha.Suite | string, extension: MockFileFormat = 'json'): Promise<object | string> {
+	let relativePath: string;
+
+	if (typeof contextOrSuiteOrString === 'string') {
+		relativePath = `${contextOrSuiteOrString}.${extension}`;
+	} else {
+		relativePath = utils.generateFileNameForTest(contextOrSuiteOrString, extension);
+	}
+
+	const mockFilePath = 'src/test/mocks/' + relativePath;
+
 	const mockContents = await getMock(mockFilePath);
 	if (extension === 'json') {
 		return JSON.parse(mockContents);
@@ -17,9 +26,9 @@ export async function getTestMock(contextOrSuite: Mocha.Context | Mocha.Suite, e
 	}
 }
 
-export async function getNeedleMockResponse(contextOrSuite: Mocha.Context | Mocha.Suite, extension: MockFileFormat = 'json'): Promise<needle.NeedleResponse> {
+export async function getNeedleMockResponse(contextOrSuiteOrString: Mocha.Context | Mocha.Suite | string, extension: MockFileFormat = 'json'): Promise<needle.NeedleResponse> {
 	const mock: any = {
-		body: await getTestMock(contextOrSuite, extension)
+		body: await getTestMock(contextOrSuiteOrString, extension)
 	};
 	return mock;
 }

--- a/client/src/types/AppUIResponse.ts
+++ b/client/src/types/AppUIResponse.ts
@@ -16,7 +16,7 @@ export interface AppUIResponseChild {
 	base: keyof typeof BaseType;
 	keyPath: string;
 	subtype: string;
-	sceneRect: BoundingRect;
+	sceneRect?: BoundingRect;
 	bounds?: number[];
 	children?: AppUIResponseChild[];
 	color?: string;

--- a/client/src/types/AppUIResponse.ts
+++ b/client/src/types/AppUIResponse.ts
@@ -1,0 +1,36 @@
+import type { BaseType, BoundingRect } from './OnDeviceComponent';
+
+export interface AppUIResponse {
+	plugin: {
+		id: string;
+		name: string;
+	};
+	screen: {
+		focused: boolean;
+		type: string;
+		children: AppUIResponseChild[];
+	};
+}
+
+export interface AppUIResponseChild {
+	base: keyof typeof BaseType;
+	keyPath: string;
+	subtype: string;
+	sceneRect: BoundingRect;
+	bounds?: number[];
+	children?: AppUIResponseChild[];
+	color?: string;
+	extends?: string;
+	focusable?: boolean;
+	focused?: boolean;
+	id?: string;
+	inheritParentOpacity?: boolean;
+	inheritParentTransform?: boolean;
+	name?: string;
+	opacity?: number;
+	text?: string;
+	translation?: number[];
+	uiElementId?: string;
+	uri?: string;
+	visible?: boolean;
+}

--- a/client/src/types/OnDeviceComponent.ts
+++ b/client/src/types/OnDeviceComponent.ts
@@ -467,4 +467,7 @@ export interface CancelRequestArgs {
 	id: string;
 }
 
-export interface ConvertKeyPathToSceneKeyPathArgs extends BaseKeyPath {}
+export interface ConvertKeyPathToSceneKeyPathArgs extends BaseKeyPath {
+	/** If we are trying to convert an appUI key path then we need to split up the key path for several edge cases */
+	arrayGridChildElementId?: string;
+}

--- a/client/src/types/OnDeviceComponent.ts
+++ b/client/src/types/OnDeviceComponent.ts
@@ -1,9 +1,11 @@
 import type { Socket } from 'net';
+import type { AppUIResponse } from './AppUIResponse';
 
 export enum RequestType {
 	assignElementIdOnAllNodes = 'assignElementIdOnAllNodes',
 	callFunc = 'callFunc',
 	cancelRequest = 'cancelRequest',
+	convertKeyPathToSceneKeyPath = 'convertKeyPathToSceneKeyPath',
 	createDirectory = 'createDirectory',
 	createChild = 'createChild',
 	deleteFile = 'deleteFile',
@@ -49,6 +51,7 @@ export enum RequestType {
 export type RequestArgs = CallFuncArgs | CreateChildArgs | GetFocusedNodeArgs | GetValueArgs | GetValuesArgs | HasFocusArgs | IsInFocusChainArgs | OnFieldChangeArgs | CancelRequestArgs | SetValueArgs | ReadRegistryArgs | WriteRegistryArgs | DeleteRegistrySectionsArgs | DeleteEntireRegistrySectionsArgs | StoreNodeReferencesArgs | GetNodesInfoArgs | FindNodesAtLocationArgs | CreateDirectoryArgs | DeleteEntireRegistrySectionsArgs | DeleteFileArgs | DeleteNodeReferencesArgs | DisableScreensaverArgs | FocusNodeArgs | GetAllCountArgs | GetDirectoryListingArgs | GetNodesWithPropertiesArgs | GetRootsCountArgs | GetServerHostArgs | GetVolumeListArgs | IsShowingOnScreenArgs | IsSubtypeArgs | ReadFileArgs | RenameFileArgs | SetSettingsArgs | StartResponsivenessTestingArgs | StatPathArgs | WriteFileArgs | RemoveNodeArgs |RemoveNodeChildrenArgs | DisableScreensaverArgs;
 
 export enum BaseType {
+	appUI = 'appUI',
 	elementId = 'elementId',
 	focusedNode = 'focusedNode',
 	global = 'global',
@@ -66,6 +69,9 @@ interface NodeRefKey {
 export interface BaseArgs extends NodeRefKey {
 	/** Specifies what the entry point is for this key path. Defaults to 'global' if not specified */
 	base?: BaseType |  keyof typeof BaseType;
+
+	/** If base type is appUI then a request will normally be made to the device using ecp.getAppUI. If you wish to avoid this extra call for multiple requests in a row you can pass in an AppUIResponse. */
+	appUIResponse?: AppUIResponse;
 }
 
 export interface BaseKeyPath extends BaseArgs, MaxChildDepth {
@@ -460,3 +466,5 @@ export interface SetSettingsArgs {
 export interface CancelRequestArgs {
 	id: string;
 }
+
+export interface ConvertKeyPathToSceneKeyPathArgs extends BaseKeyPath {}

--- a/client/src/types/OnDeviceComponent.ts
+++ b/client/src/types/OnDeviceComponent.ts
@@ -1,6 +1,7 @@
 import type { Socket } from 'net';
 
 export enum RequestType {
+	assignElementIdOnAllNodes = 'assignElementIdOnAllNodes',
 	callFunc = 'callFunc',
 	cancelRequest = 'cancelRequest',
 	createDirectory = 'createDirectory',
@@ -28,6 +29,7 @@ export enum RequestType {
 	isSubtype = 'isSubtype',
 	isShowingOnScreen = 'isShowingOnScreen',
 	onFieldChange = 'onFieldChange',
+	onFieldChangeOnce = 'onFieldChangeOnce',
 	readFile = 'readFile',
 	readRegistry = 'readRegistry',
 	removeNode = 'removeNode',
@@ -47,10 +49,11 @@ export enum RequestType {
 export type RequestArgs = CallFuncArgs | CreateChildArgs | GetFocusedNodeArgs | GetValueArgs | GetValuesArgs | HasFocusArgs | IsInFocusChainArgs | OnFieldChangeArgs | CancelRequestArgs | SetValueArgs | ReadRegistryArgs | WriteRegistryArgs | DeleteRegistrySectionsArgs | DeleteEntireRegistrySectionsArgs | StoreNodeReferencesArgs | GetNodesInfoArgs | FindNodesAtLocationArgs | CreateDirectoryArgs | DeleteEntireRegistrySectionsArgs | DeleteFileArgs | DeleteNodeReferencesArgs | DisableScreensaverArgs | FocusNodeArgs | GetAllCountArgs | GetDirectoryListingArgs | GetNodesWithPropertiesArgs | GetRootsCountArgs | GetServerHostArgs | GetVolumeListArgs | IsShowingOnScreenArgs | IsSubtypeArgs | ReadFileArgs | RenameFileArgs | SetSettingsArgs | StartResponsivenessTestingArgs | StatPathArgs | WriteFileArgs | RemoveNodeArgs |RemoveNodeChildrenArgs | DisableScreensaverArgs;
 
 export enum BaseType {
+	elementId = 'elementId',
+	focusedNode = 'focusedNode',
 	global = 'global',
-	scene = 'scene',
 	nodeRef = 'nodeRef',
-	focusedNode = 'focusedNode'
+	scene = 'scene'
 }
 
 export declare type LogLevels = 'off' | 'error' | 'warn' | 'info' | 'debug' | 'verbose';
@@ -240,6 +243,11 @@ export interface StoreNodeReferencesArgs extends NodeRefKey {
 	includeBoundingRectInfo?: boolean;
 }
 
+export interface AssignElementIdOnAllNodesArgs {
+	/** True by default. If false will regenerate a new element id for all elements even if one was previously assigned */
+	maintainExistingElementId?: boolean;
+}
+
 export interface StoreNodeReferencesResponse extends ReturnTimeTaken {
 	flatTree: TreeNode[];
 	rootTree: TreeNode[];
@@ -250,6 +258,9 @@ export interface StoreNodeReferencesResponse extends ReturnTimeTaken {
 		height: number;
 		resolution: 'FHD' | 'HD';
 	}
+}
+
+export interface AssignElementIdOnAllNodesResponse extends ReturnTimeTaken {
 }
 
 export interface DeleteNodeReferencesArgs extends NodeRefKey {}

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -281,9 +281,11 @@ class Utils {
 		return Math.floor(Math.random() * (max - min + 1) ) + min;
 	}
 
-	public findNodesAtLocation(appUIResponse: AppUIResponse, x: number, y: number) {
+	public findNodesAtLocation(args: { appUIResponse: AppUIResponse, x: number, y: number, includeMatchesWithoutKeyPath?: boolean }) {
 		const matches = [] as AppUIResponseChild[];
-		this.findNodesAtLocationCore(x, y, appUIResponse.screen.children, matches);
+		this.findNodesAtLocationCore({...args , children: args.appUIResponse.screen.children, matches: matches});
+
+		const {x, y} = args;
 
 		// We now want to sort our matches to try and return the best one first
 		matches.sort((a, b) => {
@@ -314,7 +316,11 @@ class Utils {
 		};
 	}
 
-	private findNodesAtLocationCore(x: number, y: number, children: AppUIResponseChild[], matches: AppUIResponseChild[], isArrayGridChild = false) {
+	private findNodesAtLocationCore(args: {x: number, y: number, children: AppUIResponseChild[], matches: AppUIResponseChild[], isArrayGridChild?: boolean, includeMatchesWithoutKeyPath?: boolean}) {
+		let isArrayGridChild = args.isArrayGridChild ?? false;
+
+		const {x, y, children, matches} = args;
+
 		for (const child of children) {
 			let isLocationWithinNodeDimensions = false;
 			if (child.sceneRect) {
@@ -329,11 +335,13 @@ class Utils {
 
 			if ((isLocationWithinNodeDimensions && isVisible) || isArrayGridChild) {
 				if (isLocationWithinNodeDimensions && isVisible) {
-					matches.push(child);
+					if (child.keyPath != undefined || args.includeMatchesWithoutKeyPath) {
+						matches.push(child);
+					}
 				}
 
 				if (child.children?.length) {
-					this.findNodesAtLocationCore(x, y, child.children, matches, isArrayGridChild);
+					this.findNodesAtLocationCore({x: x, y: y, children: child.children, matches: matches, isArrayGridChild: isArrayGridChild});
 				}
 			}
 		}

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -5,6 +5,8 @@ import * as Ajv from 'ajv';
 const ajv = new Ajv();
 
 import type { ConfigOptions, DeviceConfigOptions } from './types/ConfigOptions';
+import type { BoundingRect } from './types/OnDeviceComponent';
+import type { AppUIResponse, AppUIResponseChild } from './types/AppUIResponse';
 type PathType = typeof path;
 
 class Utils {
@@ -24,7 +26,7 @@ class Utils {
 		return this.path;
 	}
 
-	private getFsExtra() {
+	public getFsExtra() {
 		if (!this.fsExtra) {
 			this.fsExtra = this.require<typeof fsExtra>('fs-extra');
 		}
@@ -277,6 +279,79 @@ class Utils {
 
 	public randomInteger(max = 2147483647, min = 0) {
 		return Math.floor(Math.random() * (max - min + 1) ) + min;
+	}
+
+	public findNodesAtLocation(appUIResponse: AppUIResponse, x: number, y: number) {
+		const matches = [] as AppUIResponseChild[];
+		this.findNodesAtLocationCore(x, y, appUIResponse.screen.children, matches);
+
+		// We now want to sort our matches to try and return the best one first
+		matches.sort((a, b) => {
+			const aOffest = this.calculateRectCenterPointOffsetFromLocation(x, y, a.sceneRect as BoundingRect);
+			const bOffset = this.calculateRectCenterPointOffsetFromLocation(x, y, b.sceneRect as BoundingRect);
+			const difference = (Math.abs(aOffest.x) + Math.abs(aOffest.y)) - (Math.abs(bOffset.x) + Math.abs(bOffset.y));
+			if (difference === 0) {
+				// If both items have the exact same size and position then we want to return the deepest one.
+				if (a.keyPath && b.keyPath) {
+					const aKeyPath = a.keyPath.split('.');
+					const bKeyPath = b.keyPath.split('.');
+					if (aKeyPath.length < bKeyPath.length) {
+						return difference + .1;
+					} else if (aKeyPath.length > bKeyPath.length) {
+						return difference - .1;
+					}
+				} else if (a.keyPath) {
+					return difference - .1;
+				} else {
+					return difference + .1;
+				}
+			}
+			return difference;
+		});
+
+		return {
+			matches
+		};
+	}
+
+	private findNodesAtLocationCore(x: number, y: number, children: AppUIResponseChild[], matches: AppUIResponseChild[], isArrayGridChild = false) {
+		for (const child of children) {
+			let isLocationWithinNodeDimensions = false;
+			if (child.sceneRect) {
+				const rect = child.sceneRect;
+				isLocationWithinNodeDimensions = (x >= rect.x && x <= rect.x + rect.width && y >= rect.y && y <= rect.y + rect.height);
+			}
+			const isVisible = (child.visible && !!child.opacity);
+
+			if (child.subtype == 'RowListItem') {
+				isArrayGridChild = true;
+			}
+
+			if ((isLocationWithinNodeDimensions && isVisible) || isArrayGridChild) {
+				if (isLocationWithinNodeDimensions && isVisible) {
+					matches.push(child);
+				}
+
+				if (child.children?.length) {
+					this.findNodesAtLocationCore(x, y, child.children, matches, isArrayGridChild);
+				}
+			}
+		}
+	}
+
+	private calculateRectCenterPoint(rect: BoundingRect) {
+		return {
+			x: (rect.x - rect.width) / 2,
+			y: (rect.y - rect.height) / 2
+		};
+	}
+
+	private calculateRectCenterPointOffsetFromLocation(x: number, y: number, rect: BoundingRect) {
+		const centerPoint = this.calculateRectCenterPoint(rect);
+		return {
+			x: x - centerPoint.x,
+			y: y - centerPoint.y
+		};
 	}
 }
 

--- a/device/components/RTA_OnDeviceComponent.brs
+++ b/device/components/RTA_OnDeviceComponent.brs
@@ -44,7 +44,16 @@ end sub
 
 sub onRenderThreadRequestChange(event as Object)
 	request = event.getData()
-	RTA_logDebug("Received request: ", formatJson(request))
+
+	' Don't want to take the overhead if we are not logging debug
+	if RTA_canLog("debug") then
+		json = formatJson(request)
+		if json.len() > 1000 then
+			json = "large request showing first 1000 characters: " + json.left(1000) + "..."
+		end if
+
+		RTA_logDebug("Received request: ", json)
+	end if
 
 	requestType = request.type
 	request.timespan = createObject("roTimespan")

--- a/device/components/RTA_helpers.brs
+++ b/device/components/RTA_helpers.brs
@@ -721,12 +721,21 @@ sub RTA_log(level as Integer, message as String, value = "nil" as Dynamic)
 	date.toLocalTime()
 	formattedDate = RTA_lpad(date.getMonth()) + "-" + RTA_lpad(date.getDayOfMonth()) + " " + RTA_lpad(date.getHours()) + ":" + RTA_lpad(date.getMinutes()) + ":" + RTA_lpad(date.getSeconds()) + "." + RTA_lpad(date.getMilliseconds(), 3)
 	message = formattedDate + " [RTA][" + levels[level] + "] " + message
+
 	if RTA_isString(value) AND value = "nil" then
 		print message
 	else
 		print message value
 	end if
 end sub
+
+function RTA_canLog(level as String) as Boolean
+	if RTA_isNumber(m.logLevel) AND m.logLevel < RTA_convertLogLevelStringToInteger(level) then
+		return false
+	end if
+
+	return true
+end function
 
 function RTA_lpad(value as Dynamic, padLength = 2 as Integer, padCharacter = "0" as String)
 	value = value.toStr()

--- a/testProject/components/MainScene.brs
+++ b/testProject/components/MainScene.brs
@@ -28,14 +28,13 @@ sub init()
 
 	landingPage = m.top.pagesContainer.createChild("LandingPage")
 	setFocus(landingPage)
-	
+
 	'To test the onFieldChangeRepeat
 	m.repeatingTimer = createObject("roSGNode","Timer")
 	m.repeatingTimer.observeFieldScoped("fire", "onRepeatingTimerFired")
 	m.repeatingTimer.duration = 1
 	m.repeatingTimer.repeat = true
 	m.repeatingTimer.control = "start"
-
 end sub
 
 sub onRepeatingTimerFired()

--- a/testProject/components/MainScene.xml
+++ b/testProject/components/MainScene.xml
@@ -8,7 +8,7 @@
 		<function name="setPosterUrl" />
 	</interface>
 	<children>
-		<Poster id="poster" />
+		<Poster id="poster" translation="[10, 20]" />
 		<Rectangle id="invisibleRect" width="1920" height="1080" color="#FF0000" visible="false" />
 		<Animation id="animation" />
 		<Group id="temporaryNodesGroup" />

--- a/testProject/components/Pages/LandingPage/LandingPage.brs
+++ b/testProject/components/Pages/LandingPage/LandingPage.brs
@@ -38,7 +38,7 @@ function makeRowListContent()
 		row.id = row.title
 		itemCount = 1
 		if rowIndex MOD 2 = 1 then
-			itemCount = 8
+			itemCount = 50
 		end if
 		for itemIndex = 0 to itemCount - 1
 			item = row.createChild("ContentNode")

--- a/testProject/components/Pages/LandingPage/LandingPage.xml
+++ b/testProject/components/Pages/LandingPage/LandingPage.xml
@@ -53,7 +53,7 @@
 			rowItemSpacing="[[30, 0]]"
 			rowItemSize="[[300, 150]]"
 			translation="[150, 700]" />
-		<MarkupGrid
+		<CustomMarkupGrid
 			id="markupGrid"
 			itemComponentName="MarkupGridItemComponent"
 			itemSize="[150, 150]"

--- a/testProject/components/Pages/LandingPage/LandingPage.xml
+++ b/testProject/components/Pages/LandingPage/LandingPage.xml
@@ -10,7 +10,9 @@
 	</interface>
 	<children>
 		<Rectangle id="rect" width="1920" height="1080" color="#111111" />
-		<Rectangle id="rect2" width="100" height="100" color="#00FF00" translation="[100, 100]" />
+		<Rectangle id="rect2" width="100" height="100" color="#00FF00" translation="[100, 100]">
+			<Rectangle id="rect3" width="50" height="50" color="#0000FF" translation="[25, 25]" />
+		</Rectangle>
 		<AppButton id="loginButton" text="Login" translation="[300, 150]" />
 		<Group id="testTarget">
 			<Group id="child1" />

--- a/testProject/components/Pages/LandingPage/LandingPage.xml
+++ b/testProject/components/Pages/LandingPage/LandingPage.xml
@@ -13,6 +13,14 @@
 		<Rectangle id="rect2" width="100" height="100" color="#00FF00" translation="[100, 100]">
 			<Rectangle id="rect3" width="50" height="50" color="#0000FF" translation="[25, 25]" />
 		</Rectangle>
+
+		<Group id="offsetGroup" translation="[1500, 100]">
+			<Rectangle id="offsetGroupRect1" width="100" height="100" color="#FF0000" translation="[100, 100]" />
+			<Rectangle id="offsetGroupRect2" width="100" height="100" color="#00FF00"  translation="[300, 100]">
+				<Rectangle id="offsetGroupRect2_child" width="50" height="50" color="#0000FF" translation="[25, 25]" />
+			</Rectangle>
+		</Group>
+
 		<AppButton id="loginButton" text="Login" translation="[300, 150]" />
 		<Group id="testTarget">
 			<Group id="child1" />

--- a/testProject/components/elements/CustomMarkupGrid/CustomMarkupGrid.xml
+++ b/testProject/components/elements/CustomMarkupGrid/CustomMarkupGrid.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="CustomMarkupGrid" extends="MarkupGrid">
+</component>


### PR DESCRIPTION
This PR serves as the first step in moving away from storeNodeReferences in favor of using Roku's app-ui API instead. For context the vscode extension PR that is the primary use of this work is here: https://github.com/rokucommunity/vscode-brightscript-language/pull/661. It is still to be determined if storeNodeReferences will completely go away with 3.0. At the very least the plan is to remove all of the custom code to try and access ArrayGrid children