### PR TITLE
chore: Update create-vsix to support multi-vsix and shared bot logic

### DIFF
--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -2,10 +2,15 @@ name: create-vsix
 on:
   pull_request:
     types: [labeled, unlabeled, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "The pull request to build a vsix for (PR number or full PR URL)"
+        required: true
 jobs:
   create-vsix:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'create-vsix')
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'create-vsix')
     steps:
       # Get a bot token so the bot's name shows up on all our actions
       - name: Get Token From roku-ci-token Application
@@ -16,27 +21,16 @@ jobs:
           private_key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Set New GitHub Token
         run: echo "TOKEN=${{ steps.generate-token.outputs.token }}" >> $GITHUB_ENV
-      #trigger the build on vscode-brightscript-language
-      - name: Build vsix for branch "${{ github.head_ref}}"
+      # Trigger the build on vscode-brightscript-language. That workflow interprets these
+      # inputs, builds the .vsix files, and posts the download links back on the PR
+      - name: Build vsix
         uses: aurelien-baudet/workflow-dispatch@v2.1.1
         id: create-vsix
         with:
-         workflow: create-vsix
-         ref: master
-         wait-for-completion: true
-         display-workflow-run-url: true
-         repo: rokucommunity/vscode-brightscript-language
-         token: ${{ env.TOKEN }}
-         inputs: '{ "branch": "${{ github.head_ref }}"}'
-      #add a comment on the PR
-      - name: Add comment to PR
-        uses: actions/github-script@v5
-        with:
-          github-token: ${{ env.TOKEN }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Hey there! I just built a new version of the vscode extension based on ${{ github.event.pull_request.head.sha }}. You can download the .vsix [here](${{steps.create-vsix.outputs.workflow-url}}) and then follow [these installation instructions](https://github.com/rokucommunity/vscode-brightscript-language#pre-release-versions).'
-            })
+          workflow: create-vsix
+          ref: master
+          wait-for-completion: true
+          display-workflow-run-url: true
+          repo: rokucommunity/vscode-brightscript-language
+          token: ${{ env.TOKEN }}
+          inputs: '{ "branch": "${{ github.head_ref }}", "pr": "${{ github.event.pull_request.html_url || github.event.inputs.pr }}", "repo": "${{ github.repository }}" }'


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` trigger (with a `pr` input accepting a PR number or full URL) so this can be tested without needing a labeled PR
- Forwards `branch`, `pr`, and `repo` to vscode-brightscript-language's `create-vsix` workflow, which now interprets these inputs itself and posts the download-links comment directly on the originating PR
- Drops the local "Add comment to PR" step since it's now redundant — the comment is posted by vscode-brightscript-language's workflow instead
- Keeps `wait-for-completion: true` so this job's pass/fail status still reflects whether the actual vsix build succeeded

Note: `roku-test-automation` was recently added as a proper dependency in vscode-brightscript-language's `create-vsix.ts` build graph (see rokucommunity/vscode-brightscript-language#847) — before that, this trigger built successfully but silently ignored the PR's actual changes.