### PR TITLE
chore: Give fork PRs a clear create-vsix failure message

### DIFF
--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'create-vsix')
     steps:
+      # GitHub withholds repository secrets from fork-triggered runs, so fail fast with a clear message
+      - name: Reject fork PRs
+        if: github.event.pull_request.head.repo.fork
+        run: |
+          echo "::error::Could not build a .vsix because fork PRs can't access the required secrets. Ask a maintainer to dispatch it manually for PR #${{ github.event.pull_request.number }}: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
+          exit 1
       # Get a bot token so the bot's name shows up on all our actions
       - name: Get Token From roku-ci-token Application
         uses: tibdex/github-app-token@v1


### PR DESCRIPTION
### Problem

Applying the `create-vsix` label to a PR opened from a fork starts this job, but GitHub withholds repository secrets from fork-triggered runs. The run then died with a cryptic:

```
Input required and not supplied: app_id
```

Nothing in that message says "this is a fork" or "here's what to do instead", so it reads like a broken workflow rather than an expected limitation.

### Change

Detect the fork up front and fail immediately with an actionable message:

```yaml
# GitHub withholds repository secrets from fork-triggered runs, so fail fast with a clear message
- name: Reject fork PRs
  if: github.event.pull_request.head.repo.fork
  run: |
    echo "::error::Could not build a .vsix because fork PRs can't access the required secrets. Ask a maintainer to dispatch it manually for PR #${{ github.event.pull_request.number }}: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
    exit 1
```

Notes:

- Uses `::error::` so the text surfaces as an annotation in the Actions UI, not just in the log.
- The PR number and workflow link are built from context, so the step is identical across every repo.
- On `workflow_dispatch` there's no `pull_request` payload, so the `if` is falsy and the step skips — that's the path a maintainer uses to build a fork PR's .vsix.
- Runs as the first step, so a fork PR fails in seconds.

Matches rokucommunity/vscode-brightscript-language#864, where the message and annotation rendering were verified on a live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
